### PR TITLE
Allow self-signed certificates in downstream services

### DIFF
--- a/.kube.dev.yaml
+++ b/.kube.dev.yaml
@@ -4,4 +4,5 @@
   clients: queue-consumer
   image: quay.io/ukhomeofficedigital/asl-workflow:{{.DRONE_COMMIT_SHA}}
   env:
+    NODE_TLS_REJECT_UNAUTHORIZED: '"0"'
     RESOLVER_URL: https://resolver:10443


### PR DESCRIPTION
The resolver API will run with a self-signed cert, so we need to configure node to allow this.