### PR TITLE
Add caching support for decorator queries

### DIFF
--- a/lib/decorators/cacheable.js
+++ b/lib/decorators/cacheable.js
@@ -1,0 +1,33 @@
+module.exports = (settings = {}) => {
+
+  settings.ttl = settings.ttl || 60000;
+
+  const cache = {};
+
+  const query = (Model, id) => {
+    const key = `${Model.tableName}:${id}`;
+    if (cache[key] && cache[key].updated + settings.ttl > Date.now()) {
+      return cache[key].result;
+    } else {
+      const result = Model.query().findById(id);
+      cache[key] = {
+        updated: Date.now(),
+        result
+      };
+      return result;
+    }
+  };
+
+  const clean = () => {
+    Object.keys(cache).forEach(key => {
+      if (cache[key].updated + settings.ttl < Date.now()) {
+        delete cache[key];
+      }
+    });
+  };
+
+  setInterval(clean, 2 * settings.ttl);
+
+  return { query };
+
+};

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -1,13 +1,17 @@
+const Cacheable = require('./cacheable');
+
 module.exports = settings => {
 
   const { Establishment, Profile } = settings.models;
 
+  const cache = Cacheable();
+
   return c => {
 
     const promises = [
-      c.data.establishmentId && Establishment.query().findById(c.data.establishmentId),
-      c.data.subject && Profile.query().findById(c.data.subject),
-      c.data.changedBy && Profile.query().findById(c.data.changedBy)
+      c.data.establishmentId && cache.query(Establishment, c.data.establishmentId),
+      c.data.subject && cache.query(Profile, c.data.subject),
+      c.data.changedBy && cache.query(Profile, c.data.changedBy)
     ];
 
     return Promise.all(promises)


### PR DESCRIPTION
Keeps references to any of the lookups by id done by decorators so that if the same lookup is performed twice in close succession then only a single database query is performed.