### PR TITLE
Rename reason to comment (more generic for taskflow)

### DIFF
--- a/lib/flow/status.js
+++ b/lib/flow/status.js
@@ -1,54 +1,54 @@
 module.exports = {
   newCase: {
     id: 'new',
-    reasonRequired: false
+    commentRequired: false
   },
   autoResolved: {
     id: 'autoresolved',
-    reasonRequired: false
+    commentRequired: false
   },
   resubmitted: {
     id: 'resubmitted',
-    reasonRequired: false
+    commentRequired: false
   },
   returnedToApplicant: {
     id: 'returned-to-applicant',
-    reasonRequired: true
+    commentRequired: true
   },
   withdrawn: {
     id: 'withdrawn-by-applicant',
-    reasonRequired: false
+    commentRequired: false
   },
   withNtco: {
     id: 'with-ntco',
-    reasonRequired: false
+    commentRequired: false
   },
   ntcoEndorsed: {
     id: 'ntco-endorsed',
-    reasonRequired: false
+    commentRequired: false
   },
   withLicensing: {
     id: 'with-licensing',
-    reasonRequired: false
+    commentRequired: false
   },
   referredToInspector: {
     id: 'referred-to-inspector',
-    reasonRequired: true
+    commentRequired: true
   },
   inspectorRecommended: {
     id: 'inspector-recommended',
-    reasonRequired: false
+    commentRequired: false
   },
   inspectorRejected: {
     id: 'inspector-rejected',
-    reasonRequired: true
+    commentRequired: true
   },
   resolved: {
     id: 'resolved',
-    reasonRequired: false
+    commentRequired: false
   },
   rejected: {
     id: 'resolved',
-    reasonRequired: true
+    commentRequired: true
   }
 };

--- a/lib/hooks/validate/payload.js
+++ b/lib/hooks/validate/payload.js
@@ -6,8 +6,8 @@ module.exports = () => {
   return model => {
     const next = getAllSteps().find(step => step.id === model.meta.next);
 
-    if (next.reasonRequired && (!has(model.meta.payload, 'reason') || isEmpty(model.meta.payload.reason))) {
-      throw new BadRequestError(`Changing status to '${model.meta.next}' requires a reason`);
+    if (next.commentRequired && (!has(model.meta.payload, 'comment') || isEmpty(model.meta.payload.comment))) {
+      throw new BadRequestError(`Changing status to '${model.meta.next}' requires a comment`);
     }
 
     return Promise.resolve();


### PR DESCRIPTION
Once https://github.com/UKHomeOffice/taskflow/pull/20 is merged, Taskflow will capture any "comment" property of the request body into an activity log.

We should make the language consistent across workflow / taskflow / pages so that we always use comment in the data (we can alias it as "Reason" with labels or whatever).