### PR TITLE
Tasklist integration tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,6 +4,13 @@ pipeline:
     image: node:10
     secrets:
       - npm_auth_token
+    environment:
+      - ASL_DATABASE_HOST=database_asl
+      - ASL_DATABASE_USERNAME=postgres
+      - ASL_DATABASE_NAME=asl-test
+      - DATABASE_HOST=database_taskflow
+      - DATABASE_USERNAME=postgres
+      - DATABASE_NAME=taskflow-test
     commands:
       - npm ci
       - npm test
@@ -67,7 +74,18 @@ pipeline:
       branch: master
       event: push
 
+services:
+  database_asl:
+    image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=asl-test
+  database_taskflow:
+    image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=taskflow-test
+
 matrix:
   NPM_AUTH_USERNAME:
     - asl
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY . /app
 
 RUN rm /app/.npmrc
 
-CMD node index.js
+CMD npm run migrate && node index.js

--- a/knexfile.js
+++ b/knexfile.js
@@ -4,7 +4,7 @@ module.exports = {
     client: 'postgres',
     connection: {
       database: process.env.DATABASE_NAME || 'taskflow',
-      host: process.env.DATABASE_HOST,
+      host: process.env.DATABASE_HOST || 'localhost',
       password: process.env.DATABASE_PASSWORD,
       port: process.env.DATABASE_PORT,
       user: process.env.DATABASE_USERNAME || 'postgres'
@@ -12,6 +12,17 @@ module.exports = {
     pool: { min: 1, max: 1 },
     seeds: {
       directory: './seeds'
+    }
+  },
+
+  test: {
+    client: 'postgres',
+    connection: {
+      database: process.env.DATABASE_NAME || 'taskflow-test',
+      host: process.env.DATABASE_HOST || 'localhost',
+      password: process.env.DATABASE_PASSWORD,
+      port: process.env.DATABASE_PORT,
+      user: process.env.DATABASE_USERNAME || 'postgres'
     }
   }
 

--- a/knexfile.js
+++ b/knexfile.js
@@ -30,7 +30,7 @@ module.exports = {
     test: {
       client: 'postgres',
       connection: {
-        database: process.env.ASL_DATABASE_NAME || 'workflow-asl-test',
+        database: process.env.ASL_DATABASE_NAME || 'asl-test',
         host: process.env.ASL_DATABASE_HOST || 'localhost',
         user: process.env.ASL_DATABASE_USERNAME || 'postgres'
       }

--- a/knexfile.js
+++ b/knexfile.js
@@ -30,7 +30,7 @@ module.exports = {
     test: {
       client: 'postgres',
       connection: {
-        database: process.env.ASL_DATABASE_NAME || 'taskflow-test',
+        database: process.env.ASL_DATABASE_NAME || 'workflow-asl-test',
         host: process.env.ASL_DATABASE_HOST || 'localhost',
         user: process.env.ASL_DATABASE_USERNAME || 'postgres'
       }

--- a/knexfile.js
+++ b/knexfile.js
@@ -24,6 +24,17 @@ module.exports = {
       port: process.env.DATABASE_PORT,
       user: process.env.DATABASE_USERNAME || 'postgres'
     }
+  },
+
+  asl: {
+    test: {
+      client: 'postgres',
+      connection: {
+        database: process.env.ASL_DATABASE_NAME || 'taskflow-test',
+        host: process.env.ASL_DATABASE_HOST || 'localhost',
+        user: process.env.ASL_DATABASE_USERNAME || 'postgres'
+      }
+    }
   }
 
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -32,7 +32,7 @@ module.exports = settings => {
   flow.hook(`pre-status:*:${resolved.id}`, hooks.resolve(settings));
 
   // todo: find a better way to run the migrations so it doesn't run for each test?
-  // flow.migrate();
+  flow.migrate();
 
   app.use('/', tasksRouter(flow));
   app.use(flow);

--- a/lib/api.js
+++ b/lib/api.js
@@ -31,9 +31,6 @@ module.exports = settings => {
   flow.hook(`pre-status:*:${autoResolved.id}`, hooks.resolve(settings));
   flow.hook(`pre-status:*:${resolved.id}`, hooks.resolve(settings));
 
-  // todo: find a better way to run the migrations so it doesn't run for each test?
-  flow.migrate();
-
   app.use('/', tasksRouter(flow));
   app.use(flow);
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -31,7 +31,8 @@ module.exports = settings => {
   flow.hook(`pre-status:*:${autoResolved.id}`, hooks.resolve(settings));
   flow.hook(`pre-status:*:${resolved.id}`, hooks.resolve(settings));
 
-  flow.migrate();
+  // todo: find a better way to run the migrations so it doesn't run for each test?
+  // flow.migrate();
 
   app.use('/', tasksRouter(flow));
   app.use(flow);

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,6 +309,12 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
@@ -1492,6 +1498,15 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
@@ -1601,6 +1616,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1764,6 +1785,12 @@
           "dev": true
         }
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -2781,6 +2808,23 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
       "dev": true
     },
     "forwarded": {
@@ -6118,6 +6162,34 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "supertest": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.3.0.tgz",
+      "integrity": "sha512-dMQSzYdaZRSANH5LL8kX3UpgK9G1LRh/jnggs/TI0W2Sz7rkMx9Y48uia3K9NgcaWEV28tYkBnXE4tiFC77ygQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
+      }
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-bC0NbCnxc4g4h5/WXEAwcH/I/ds="
     },
     "@asl/schema": {
-      "version": "7.0.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.0.0.tgz",
-      "integrity": "sha1-squhH/SQh5hxP7ZABw5BG1pSpdA=",
+      "version": "7.4.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.4.3.tgz",
+      "integrity": "sha1-WtwJqRjo8vPwFd+n8N6duuH69vY=",
       "requires": {
         "@asl/constants": "^0.0.1",
         "knex": "^0.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4322,11 +4322,6 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
-    "test:unit": "NODE_ENV=test mocha ./test --recursive --exit",
+    "test:unit": "NODE_ENV=test npm run migrate && mocha ./test --recursive --exit",
     "dev": "nodemon -r dotenv/config index.js",
-    "seed": "SNAKE_MAPPER=true knex seed:run"
+    "seed": "SNAKE_MAPPER=true knex seed:run",
+    "migrate": "node ./scripts/migrate.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dotenv": "^6.0.0",
     "eslint": "^5.0.1",
     "eslint-config-lennym": "^2.0.1",
+    "knex": "^0.15.2",
     "mocha": "^5.2.0",
     "nodemon": "^1.17.5",
     "supertest": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
-    "test:unit": "NODE_ENV=test npm run migrate && mocha ./test --recursive --exit",
+    "test:unit": "NODE_ENV=test npm run migrate:test && mocha ./test --recursive --exit",
     "dev": "nodemon -r dotenv/config index.js",
     "seed": "SNAKE_MAPPER=true knex seed:run",
-    "migrate": "node ./scripts/migrate.js"
+    "migrate": "node ./scripts/migrate.js",
+    "migrate:test": "node ./scripts/migrate-test.js"
   },
   "repository": {
     "type": "git",
@@ -23,7 +24,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-workflow#readme",
   "dependencies": {
-    "@asl/schema": "^7.0.0",
+    "@asl/schema": "^7.4.3",
     "@asl/service": "^6.1.5",
     "@ukhomeoffice/taskflow": "^0.9.0",
     "aws-sdk": "^2.270.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint": "^5.0.1",
     "eslint-config-lennym": "^2.0.1",
     "mocha": "^5.2.0",
-    "nodemon": "^1.17.5"
+    "nodemon": "^1.17.5",
+    "supertest": "^3.3.0"
   }
 }

--- a/scripts/migrate-test.js
+++ b/scripts/migrate-test.js
@@ -5,15 +5,22 @@ const dbConfig = require('../knexfile');
 
 const migrate = () => {
   return Promise.resolve()
-    .then(() => Taskflow({ db: dbConfig.test.connection }).migrate())
     .then(() => {
+      console.log('migrate taskflow test db');
+      return Taskflow({ db: dbConfig.test.connection }).migrate();
+    })
+    .then(() => {
+      console.log('migrate asl test db');
       process.chdir('./node_modules/@asl/schema');
       return knex(dbConfig.asl.test).migrate.latest();
-    })
-    .catch(err => {
-      console.log(err);
-      process.exit(1);
     });
 };
 
-migrate();
+migrate()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch(err => {
+    console.log(err);
+    process.exit(1);
+  });

--- a/scripts/migrate-test.js
+++ b/scripts/migrate-test.js
@@ -1,0 +1,19 @@
+/* eslint-disable implicit-dependencies/no-implicit */
+const knex = require('knex');
+const Taskflow = require('@ukhomeoffice/taskflow');
+const dbConfig = require('../knexfile');
+
+const migrate = () => {
+  return Promise.resolve()
+    .then(() => Taskflow({ db: dbConfig.test.connection }).migrate())
+    .then(() => {
+      process.chdir('./node_modules/@asl/schema');
+      return knex(dbConfig.asl.test).migrate.latest();
+    })
+    .catch(err => {
+      console.log(err);
+      process.exit(1);
+    });
+};
+
+migrate();

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,24 +1,9 @@
-/* eslint-disable implicit-dependencies/no-implicit */
-const knex = require('knex');
 const Taskflow = require('@ukhomeoffice/taskflow');
-const dbConfig = require('../knexfile');
+const config = require('../config');
 
 const migrate = () => {
-  if (process.env.NODE_ENV === 'test') {
-    return Promise.resolve()
-      .then(() => Taskflow({ db: dbConfig.test.connection }).migrate())
-      .then(() => {
-        process.chdir('./node_modules/@asl/schema');
-        return knex(dbConfig.asl.test).migrate.latest();
-      })
-      .catch(err => {
-        console.log(err);
-        process.exit(1);
-      });
-  }
-
   return Promise.resolve()
-    .then(() => Taskflow({ db: dbConfig.development.connection }).migrate())
+    .then(() => Taskflow({ db: config.taskflowDB }).migrate())
     .catch(err => {
       console.log(err);
       process.exit(1);

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,6 +1,28 @@
+/* eslint-disable implicit-dependencies/no-implicit */
+const knex = require('knex');
 const Taskflow = require('@ukhomeoffice/taskflow');
 const dbConfig = require('../knexfile');
 
-const taskflowDB = process.env.NODE_ENV === 'test' ? dbConfig.test.connection : dbConfig.development.connection;
+const migrate = () => {
+  if (process.env.NODE_ENV === 'test') {
+    return Promise.resolve()
+      .then(() => Taskflow({ db: dbConfig.test.connection }).migrate())
+      .then(() => {
+        process.chdir('./node_modules/@asl/schema');
+        return knex(dbConfig.asl.test).migrate.latest();
+      })
+      .catch(err => {
+        console.log(err);
+        process.exit(1);
+      });
+  }
 
-Taskflow({ db: taskflowDB }).migrate();
+  return Promise.resolve()
+    .then(() => Taskflow({ db: dbConfig.development.connection }).migrate())
+    .catch(err => {
+      console.log(err);
+      process.exit(1);
+    });
+};
+
+migrate();

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,6 @@
+const Taskflow = require('@ukhomeoffice/taskflow');
+const dbConfig = require('../knexfile');
+
+const taskflowDB = process.env.NODE_ENV === 'test' ? dbConfig.test.connection : dbConfig.development.connection;
+
+Taskflow({ db: taskflowDB }).migrate();

--- a/seeds/data/cases.json
+++ b/seeds/data/cases.json
@@ -60,5 +60,19 @@
       "changedBy": "304235c0-1a83-49f0-87ca-b11b1ad1e147",
       "establishmentId": 8201
     }
+  },
+  {
+    "status": "returned-to-applicant",
+    "data": {
+      "id": "bc2ff1bc-408d-43d4-b983-09ce3e8ddf56",
+      "data": {
+        "profileId": "304235c0-1a83-49f0-87ca-b11b1ad1e147",
+        "establishmentId": 8201
+      },
+      "model": "pil",
+      "subject": "304235c0-1a83-49f0-87ca-b11b1ad1e147",
+      "changedBy": "304235c0-1a83-49f0-87ca-b11b1ad1e147",
+      "establishmentId": 8201
+    }
   }
 ]

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -1,0 +1,221 @@
+module.exports = models => {
+
+  const { Establishment, Profile, PIL } = models;
+
+  return Promise.resolve()
+    .then(() => {
+      return Profile.query().insertGraph([
+        {
+          id: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+          userId: 'abc123',
+          title: 'Dr',
+          firstName: 'Linford',
+          lastName: 'Christie',
+          address: '1 Some Road',
+          postcode: 'A1 1AA',
+          email: 'test1@example.com',
+          telephone: '01234567890',
+          certificates: [
+            {
+              id: 'c3032cc0-7dc7-40bc-be7e-97edc4ea1072'
+            }
+          ]
+        },
+        {
+          id: 'b2b8315b-82c0-4b2d-bc13-eb13e605ee88',
+          userId: 'basic',
+          title: 'Dr',
+          firstName: 'Noddy',
+          lastName: 'Holder',
+          address: '1 Some Road',
+          postcode: 'A1 1AA',
+          email: 'test2@example.com',
+          telephone: '01234567890'
+        },
+        {
+          id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d9',
+          title: 'Dr',
+          firstName: 'Clive',
+          lastName: 'Nacwo',
+          address: '1 Some Road',
+          postcode: 'A1 1AA',
+          email: 'test3@example.com',
+          telephone: '01234567890'
+        },
+        {
+          id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d0',
+          title: 'Dr',
+          firstName: 'Noddy',
+          lastName: 'Ntco',
+          address: '1 Some Road',
+          postcode: 'A1 1AA',
+          email: 'test4@example.com',
+          telephone: '01234567890'
+        },
+        {
+          id: 'ae28fb31-d867-4371-9b4f-79019e71232f',
+          title: 'Professor',
+          firstName: 'Colin',
+          lastName: 'Jackson',
+          address: '1 Some Road',
+          postcode: 'A1 1AA',
+          email: 'test5@example.com',
+          telephone: '01234567890'
+        },
+        {
+          id: 'ae28fb31-d867-4371-9b4f-79019e71232e',
+          title: 'Mr',
+          firstName: 'Vincent',
+          lastName: 'Malloy',
+          address: '1 Some Road',
+          postcode: 'A1 1AA',
+          email: 'vincent@malloy.com',
+          telephone: '01234567890'
+        }
+      ])
+        .then(() => {
+          return Establishment.query().insertGraph([{
+            id: 100,
+            name: 'University of Croydon',
+            country: 'england',
+            address: '100 High Street',
+            email: 'test@example.com',
+            places: [
+              {
+                id: '1d6c5bb4-be60-40fd-97a8-b29ffaa2135f',
+                site: 'Lunar House',
+                name: 'Room 101',
+                suitability: ['SA', 'LA'],
+                holding: ['LTH']
+              },
+              {
+                id: '2f404b2f-656f-4cc3-b432-5aadad052fc8',
+                site: 'Lunar House',
+                name: 'Room 102',
+                suitability: ['SA'],
+                holding: ['STH']
+              },
+              {
+                id: 'a50331bb-c1d0-4068-87ca-b5a41143b0d0',
+                site: 'Lunar House',
+                name: 'Deleted room',
+                suitability: ['SA'],
+                holding: ['STH'],
+                deleted: '2018-01-01T14:00:00Z'
+              }
+            ],
+            projects: [
+              {
+                title: 'Test project 1',
+                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                expiryDate: '2040-01-01T12:00:00Z',
+                licenceNumber: 'abc123'
+              },
+              {
+                title: 'Test project 3',
+                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                expiryDate: '2010-01-01T12:00:00Z',
+                licenceNumber: 'abc456'
+              }
+            ]
+          },
+          {
+            id: 101,
+            name: 'Marvell Pharmaceuticals',
+            country: 'england',
+            address: '101 High Street',
+            email: 'test@example.com',
+            places: [
+              {
+                id: 'e859d43a-e8ab-4ae6-844a-95c978082a48',
+                site: 'Apollo House',
+                name: 'Room 101',
+                suitability: ['SA'],
+                holding: ['LTH']
+              },
+              {
+                id: '4c9f9921-92ad-465c-8f94-06f05fcb7736',
+                site: 'Apollo House',
+                name: 'Room 102',
+                suitability: ['SA'],
+                holding: ['STH']
+              }
+            ],
+            projects: [
+              {
+                title: 'Test project 2',
+                licenceHolderId: 'ae28fb31-d867-4371-9b4f-79019e71232e',
+                expiryDate: '2040-01-01T12:00:00Z',
+                licenceNumber: 'abc789'
+              }
+            ]
+          }]);
+        })
+        .then(() => {
+          return Establishment.query().upsertGraph([{
+            id: 100,
+            profiles: [
+              { id: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9' },
+              { id: 'b2b8315b-82c0-4b2d-bc13-eb13e605ee88' },
+              { id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d9' },
+              { id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d0' },
+              { id: 'ae28fb31-d867-4371-9b4f-79019e71232f' }
+            ],
+            roles: [
+              {
+                type: 'pelh',
+                profileId: 'ae28fb31-d867-4371-9b4f-79019e71232f'
+              },
+              {
+                type: 'nacwo',
+                profileId: 'a942ffc7-e7ca-4d76-a001-0b5048a057d9'
+              },
+              {
+                type: 'ntco',
+                profileId: 'a942ffc7-e7ca-4d76-a001-0b5048a057d0'
+              }
+            ]
+          },
+          {
+            id: 101,
+            profiles: [
+              { id: 'ae28fb31-d867-4371-9b4f-79019e71232f' },
+              { id: 'ae28fb31-d867-4371-9b4f-79019e71232e' }
+            ],
+            roles: [
+              {
+                type: 'pelh',
+                profileId: 'ae28fb31-d867-4371-9b4f-79019e71232f'
+              }
+            ]
+          }], { relate: true });
+        })
+        .then(() => {
+          return PIL.query().insertGraph([
+            {
+              id: '9fbe0218-995d-47d3-88e7-641fc046d7d1',
+              profileId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+              establishmentId: 100,
+              licenceNumber: 'AB-123',
+              procedures: ['A', 'B']
+            },
+            {
+              id: '247912b2-e5c6-487d-b717-f8136491f7b8',
+              profileId: 'b2b8315b-82c0-4b2d-bc13-eb13e605ee88',
+              establishmentId: 100,
+              licenceNumber: 'D-456',
+              procedures: ['D'],
+              notesCatD: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+            },
+            {
+              id: 'ba3f4fdf-27e4-461e-a251-3188faa35df5',
+              profileId: 'a942ffc7-e7ca-4d76-a001-0b5048a057d9',
+              establishmentId: 100,
+              licenceNumber: 'F-789',
+              procedures: ['F'],
+              notesCatF: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+            }
+          ]);
+        });
+    });
+};

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  default: require('./default')
+};

--- a/test/helpers/asl-db.js
+++ b/test/helpers/asl-db.js
@@ -1,0 +1,33 @@
+const Schema = require('@asl/schema');
+
+module.exports = settings => {
+
+  return {
+    init: (populate) => {
+      const schema = Schema(settings);
+      const tables = [
+        'Project',
+        'Permission',
+        'Authorisation',
+        'PIL',
+        'Place',
+        'Role',
+        'Exemption',
+        'Certificate',
+        'Profile',
+        'Invitation',
+        'Establishment'
+      ];
+      return tables.reduce((p, table) => {
+        return p.then(() => schema[table].queryWithDeleted().hardDelete());
+      }, Promise.resolve())
+        .then(() => populate && populate(schema))
+        .then(() => schema.destroy())
+        .catch(err => {
+          schema.destroy();
+          throw err;
+        });
+    }
+  };
+
+};

--- a/test/helpers/taskflow-db.js
+++ b/test/helpers/taskflow-db.js
@@ -1,0 +1,13 @@
+const Case = require('@ukhomeoffice/taskflow/lib/db/case');
+const ActivityLog = require('@ukhomeoffice/taskflow/lib/db/activity-log');
+const Database = require('@ukhomeoffice/taskflow/lib/db');
+
+module.exports = taskflowDBConfig => {
+  return Promise.resolve()
+    .then(() => {
+      const db = Database.connect(taskflowDBConfig);
+      return Promise.resolve()
+        .then(() => ActivityLog.query(db).delete())
+        .then(() => Case.query(db).delete());
+    });
+};

--- a/test/helpers/with-user.js
+++ b/test/helpers/with-user.js
@@ -1,0 +1,36 @@
+const express = require('express');
+
+const defaultProfile = {
+  id: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+  establishments: [
+    { id: 8201 }
+  ],
+  roles: []
+};
+
+const makeDummyUser = user => (req, res, next) => {
+  req.user = Object.assign({
+    id: '9c95da14-ed4a-444a-9640-814b950f4a33',
+    access_token: '12345',
+    profile: defaultProfile,
+    get: key => user[key],
+    can: () => Promise.resolve({ json: {} }),
+    allowedActions: () => Promise.resolve({})
+  }, user);
+  next();
+};
+
+const WithUser = (app, user) => {
+  const wrapper = express();
+  wrapper.use(makeDummyUser(user));
+
+  const staticRouter = express.Router();
+  wrapper.use(staticRouter);
+  wrapper.setUser = user => staticRouter.use(makeDummyUser(user));
+
+  wrapper.use(app);
+  wrapper.app = app;
+  return wrapper;
+};
+
+module.exports = WithUser;

--- a/test/helpers/workflow.js
+++ b/test/helpers/workflow.js
@@ -9,7 +9,7 @@ const settings = {
   ...config,
   db: {
     host: process.env.ASL_DATABASE_HOST || 'localhost',
-    database: process.env.ASL_DATABASE_NAME || 'workflow-asl-test',
+    database: process.env.ASL_DATABASE_NAME || 'asl-test',
     user: process.env.ASL_DATABASE_USERNAME || 'postgres'
   },
   taskflowDB: {

--- a/test/helpers/workflow.js
+++ b/test/helpers/workflow.js
@@ -19,16 +19,14 @@ const settings = {
   }
 };
 
-console.log(settings);
-
 module.exports = {
   create: (options = {}) => {
     return Promise.resolve()
       .then(() => {
         const workflow = Workflow(Object.assign({
           ...settings,
-          auth: false
-          // log: { level: 'error' }
+          auth: false,
+          log: { level: 'error' }
         }, options));
 
         return WithUser(workflow, {});

--- a/test/helpers/workflow.js
+++ b/test/helpers/workflow.js
@@ -9,7 +9,7 @@ const settings = {
   ...config,
   db: {
     host: process.env.ASL_DATABASE_HOST || 'localhost',
-    database: process.env.ASL_DATABASE_NAME || 'asl-test',
+    database: process.env.ASL_DATABASE_NAME || 'workflow-asl-test',
     user: process.env.ASL_DATABASE_USERNAME || 'postgres'
   },
   taskflowDB: {

--- a/test/helpers/workflow.js
+++ b/test/helpers/workflow.js
@@ -1,0 +1,47 @@
+const Workflow = require('../../lib/api');
+const WithUser = require('./with-user');
+const resetTaskflowDb = require('./taskflow-db');
+const aslDb = require('./asl-db');
+const config = require('../../config');
+const fixtures = require('../data');
+
+const settings = {
+  ...config,
+  db: {
+    host: process.env.ASL_DATABASE_HOST || 'localhost',
+    database: process.env.ASL_DATABASE_NAME || 'asl-test',
+    user: process.env.ASL_DATABASE_USERNAME || 'postgres'
+  },
+  taskflowDB: {
+    host: process.env.DATABASE_HOST || 'localhost',
+    database: process.env.DATABASE_NAME || 'taskflow-test',
+    user: process.env.DATABASE_USERNAME || 'postgres'
+  }
+};
+
+console.log(settings);
+
+module.exports = {
+  create: (options = {}) => {
+    return Promise.resolve()
+      .then(() => {
+        const workflow = Workflow(Object.assign({
+          ...settings,
+          auth: false
+          // log: { level: 'error' }
+        }, options));
+
+        return WithUser(workflow, {});
+      });
+  },
+
+  destroy: () => {
+    // todo
+  },
+
+  resetDBs: () => {
+    return Promise.resolve()
+      .then(() => resetTaskflowDb(settings.taskflowDB))
+      .then(() => aslDb(settings.db).init(fixtures.default));
+  }
+};

--- a/test/integration/tasks.js
+++ b/test/integration/tasks.js
@@ -1,0 +1,112 @@
+const request = require('supertest');
+const assert = require('assert');
+const workflowHelper = require('../helpers/workflow');
+
+const ntcoProfile = {
+  id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d0',
+  establishments: [ { id: 100 } ],
+  roles: [ { type: 'ntco', establishmentId: 100 } ]
+};
+
+describe('GET / (task list)', () => {
+  beforeEach(() => {
+    return workflowHelper.create()
+      .then(workflow => {
+        this.workflow = workflow;
+      })
+      .then(() => workflowHelper.resetDBs());
+  });
+
+  afterEach(() => {
+    return workflowHelper.destroy();
+  });
+
+  it('responds 200', () => {
+    return request(this.workflow)
+      .get('/')
+      .expect(200);
+  });
+
+  it('ntcos only see tasks with status "with-ntco"', () => {
+    return Promise.resolve()
+      .then(() => {
+        // make PIL application (grant)
+        return request(this.workflow)
+          .post('/')
+          .set('Content-type', 'application/json')
+          .send({
+            id: '9fbe0218-995d-47d3-88e7-641fc046d7d1',
+            data: {
+              profileId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+              establishmentId: 100
+            },
+            model: 'pil',
+            action: 'grant',
+            changedBy: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9'
+          })
+          .expect(200);
+      })
+      .then(() => {
+        this.workflow.setUser({ profile: ntcoProfile });
+        return request(this.workflow)
+          .get('/')
+          .expect(response => {
+            const tasks = response.body.data;
+            assert.equal(tasks.length, 1, '1 record was returned');
+            assert.equal(tasks[0].status, 'with-ntco');
+          });
+      });
+  });
+
+  it('applicants only see tasks that are "returned-to-applicant"', () => {
+    return Promise.resolve()
+      .then(() => {
+        // make PIL application (grant)
+        return request(this.workflow)
+          .post('/')
+          .set('Content-type', 'application/json')
+          .send({
+            id: '9fbe0218-995d-47d3-88e7-641fc046d7d1',
+            data: {
+              profileId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+              establishmentId: 100
+            },
+            model: 'pil',
+            action: 'grant',
+            changedBy: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9'
+          })
+          .expect(200);
+      })
+      .then(() => {
+        // fetch the ntco tasks to get the case id
+        this.workflow.setUser({ profile: ntcoProfile });
+        return request(this.workflow)
+          .get('/')
+          .then(response => response.body.data[0].id);
+      })
+      .then(taskId => {
+        // ntco rejects PIL application
+        this.workflow.setUser({ profile: ntcoProfile });
+        return request(this.workflow)
+          .put(`/${taskId}/status`)
+          .set('Content-type', 'application/json')
+          .send({
+            status: 'returned-to-applicant',
+            comment: 'testing status change by ntco',
+            changedBy: 'a942ffc7-e7ca-4d76-a001-0b5048a057d0'
+          })
+          .expect(200);
+      })
+      .then(() => {
+        this.workflow.setUser(); // reset user to PIL applicant
+        return request(this.workflow)
+          .get('/')
+          .expect(response => {
+            const tasks = response.body.data;
+            assert.equal(tasks.length, 1, '1 record was returned');
+            assert.equal(tasks[0].status, 'returned-to-applicant');
+          });
+      });
+  });
+
+});


### PR DESCRIPTION
This adds support for running integration tests against workflow.

It uses the `taskflow-test` and `asl-test` (`workflow-asl-test` on `localhost`) databases.

