### PR TITLE
Load profile from database not API

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,7 +26,6 @@ module.exports = {
     url: process.env.KEYCLOAK_URL,
     client: process.env.KEYCLOAK_CLIENT,
     secret: process.env.KEYCLOAK_SECRET,
-    permissions: process.env.PERMISSIONS_SERVICE,
-    profile: process.env.API_URL
+    permissions: process.env.PERMISSIONS_SERVICE
   }
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,6 +5,8 @@ const schema = require('@asl/schema');
 const { resubmitted, autoResolved, resolved } = require('./flow/status');
 const tasksRouter = require('./router/tasks');
 
+const profile = require('./middleware/profile');
+
 const hooks = {
   meta: require('./hooks/meta'),
   create: require('./hooks/create'),
@@ -16,6 +18,8 @@ const hooks = {
 module.exports = settings => {
   const app = Api(settings);
   settings.models = schema(settings.db);
+
+  app.use(profile(settings));
 
   const flow = Taskflow({ db: settings.taskflowDB });
 

--- a/lib/middleware/profile.js
+++ b/lib/middleware/profile.js
@@ -1,0 +1,18 @@
+module.exports = settings => {
+  const { Profile } = settings.models;
+  return (req, res, next) => {
+
+    if (req.user.profile) {
+      return next();
+    }
+    return Profile.query()
+      .findOne({ userId: req.user.id })
+      .eager('[roles, establishments]')
+      .then(profile => {
+        req.user.profile = profile;
+      })
+      .then(() => next())
+      .catch(next);
+
+  };
+};


### PR DESCRIPTION
The API attepts to create a profile if it can't find one, which involves a call to workflow. If workflow then tries to load the profile from the API then this causes an infinite recursive loop of the two APIs calling one another. That is bad.

Instead load the user's profile from the database directly on workflow requests.