### PR TITLE
Add task list query builders for ASRU users + refactor

### DIFF
--- a/lib/hooks/meta/default.js
+++ b/lib/hooks/meta/default.js
@@ -1,0 +1,14 @@
+const { get } = require('lodash');
+
+module.exports = (settings, model) => {
+  const action = get(model, 'data.action');
+  const data = get(model, 'data');
+
+  if (action === 'create') {
+    data.subject = get(data, 'data.profileId');
+    data.establishmentId = get(data, 'data.establishmentId');
+    return model.update(data);
+  }
+
+  return Promise.resolve();
+};

--- a/lib/hooks/meta/index.js
+++ b/lib/hooks/meta/index.js
@@ -1,4 +1,5 @@
 const { get } = require('lodash');
+const addDefaultMetadata = require('./default');
 const addPilMetadata = require('./pil');
 const addPlaceMetadata = require('./place');
 const addProfileMetadata = require('./profile');
@@ -18,7 +19,7 @@ module.exports = settings => {
         return addProfileMetadata(settings, model);
 
       default:
-        return model;
+        return addDefaultMetadata(settings, model);
     }
   };
 };

--- a/lib/query-builders/asru.js
+++ b/lib/query-builders/asru.js
@@ -1,0 +1,28 @@
+const {
+  referredToInspector,
+  withLicensing,
+  inspectorRecommended,
+  inspectorRejected,
+  returnedToApplicant,
+  resolved,
+  rejected,
+  withdrawnByApplicant
+} = require('../flow/status');
+
+module.exports = {
+
+  inProgress: (queryBuilder, profile) => {
+    queryBuilder.whereIn('status', [
+      withLicensing.id,
+      referredToInspector.id,
+      inspectorRecommended.id,
+      inspectorRejected.id,
+      returnedToApplicant.id
+    ]);
+  },
+
+  completed: (queryBuilder, profile) => {
+    queryBuilder.whereIn('status', [resolved.id, rejected.id, withdrawnByApplicant.id]);
+  }
+
+};

--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -1,4 +1,41 @@
-module.exports = {
-  applicant: require('./applicant'),
-  ntco: require('./ntco')
+const Case = require('@ukhomeoffice/taskflow/lib/models/case');
+
+const userHasRole = (role, profile) => profile.roles.some(r => r.type === role);
+
+const applicant = require('./applicant');
+const licensing = require('./licensing-officer');
+const inspector = require('./inspector');
+const ntco = require('./ntco');
+
+module.exports = ({ profile, sort, limit, offset, progress = 'outstanding' }) => {
+
+  const userIsNtco = userHasRole('ntco', profile);
+
+  const addQueryClause = (q, type) => {
+    if (typeof type[progress] !== 'function') {
+      return q;
+    }
+    return q.orWhere(builder => type[progress](builder, profile));
+  };
+
+  let query = addQueryClause(Case.query(), applicant);
+
+  if (userIsNtco) {
+    query = addQueryClause(query, ntco);
+  }
+
+  if (profile.asruUser) {
+    if (profile.asruLicensing) {
+      query = addQueryClause(query, licensing);
+    }
+    if (profile.asruInspector) {
+      query = addQueryClause(query, inspector);
+    }
+  }
+
+  query = Case.orderBy({ query, sort });
+  query = Case.paginate({ query, limit, offset });
+
+  return query;
+
 };

--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -3,9 +3,11 @@ const Case = require('@ukhomeoffice/taskflow/lib/models/case');
 const userHasRole = (role, profile) => profile.roles.some(r => r.type === role);
 
 const applicant = require('./applicant');
+const ntco = require('./ntco');
+
 const licensing = require('./licensing-officer');
 const inspector = require('./inspector');
-const ntco = require('./ntco');
+const asru = require('./asru');
 
 module.exports = ({ profile, sort, limit, offset, progress = 'outstanding' }) => {
 
@@ -30,6 +32,9 @@ module.exports = ({ profile, sort, limit, offset, progress = 'outstanding' }) =>
     }
     if (profile.asruInspector) {
       query = addQueryClause(query, inspector);
+    }
+    if (!profile.asruLicensing && !profile.asruInspector) {
+      query = addQueryClause(query, asru);
     }
   }
 

--- a/lib/query-builders/inspector.js
+++ b/lib/query-builders/inspector.js
@@ -1,5 +1,12 @@
 const {
-  referredToInspector
+  referredToInspector,
+  withLicensing,
+  inspectorRecommended,
+  inspectorRejected,
+  returnedToApplicant,
+  resolved,
+  rejected,
+  withdrawnByApplicant
 } = require('../flow/status');
 
 module.exports = {
@@ -8,10 +15,15 @@ module.exports = {
   },
 
   inProgress: (queryBuilder, profile) => {
-    // todo
+    queryBuilder.whereIn('status', [
+      withLicensing.id,
+      inspectorRecommended.id,
+      inspectorRejected.id,
+      returnedToApplicant.id
+    ]);
   },
 
   completed: (queryBuilder, profile) => {
-    // todo
+    queryBuilder.whereIn('status', [resolved.id, rejected.id, withdrawnByApplicant.id]);
   }
 };

--- a/lib/query-builders/inspector.js
+++ b/lib/query-builders/inspector.js
@@ -1,0 +1,17 @@
+const {
+  referredToInspector
+} = require('../flow/status');
+
+module.exports = {
+  outstanding: (queryBuilder, profile) => {
+    queryBuilder.whereIn('status', [referredToInspector.id]);
+  },
+
+  inProgress: (queryBuilder, profile) => {
+    // todo
+  },
+
+  completed: (queryBuilder, profile) => {
+    // todo
+  }
+};

--- a/lib/query-builders/licensing-officer.js
+++ b/lib/query-builders/licensing-officer.js
@@ -1,0 +1,19 @@
+const {
+  withLicensing,
+  inspectorRecommended,
+  inspectorRejected
+} = require('../flow/status');
+
+module.exports = {
+  outstanding: (queryBuilder, profile) => {
+    queryBuilder.whereIn('status', [withLicensing.id, inspectorRecommended.id, inspectorRejected.id]);
+  },
+
+  inProgress: (queryBuilder, profile) => {
+    // todo
+  },
+
+  completed: (queryBuilder, profile) => {
+    // todo
+  }
+};

--- a/lib/query-builders/licensing-officer.js
+++ b/lib/query-builders/licensing-officer.js
@@ -1,7 +1,12 @@
 const {
   withLicensing,
   inspectorRecommended,
-  inspectorRejected
+  inspectorRejected,
+  referredToInspector,
+  returnedToApplicant,
+  resolved,
+  rejected,
+  withdrawnByApplicant
 } = require('../flow/status');
 
 module.exports = {
@@ -10,10 +15,10 @@ module.exports = {
   },
 
   inProgress: (queryBuilder, profile) => {
-    // todo
+    queryBuilder.whereIn('status', [referredToInspector.id, returnedToApplicant.id]);
   },
 
   completed: (queryBuilder, profile) => {
-    // todo
+    queryBuilder.whereIn('status', [resolved.id, rejected.id, withdrawnByApplicant.id]);
   }
 };

--- a/lib/router/tasks.js
+++ b/lib/router/tasks.js
@@ -1,9 +1,8 @@
 const Case = require('@ukhomeoffice/taskflow/lib/models/case');
+
 const { Router } = require('express');
 const router = Router({ mergeParams: true });
-const { applicant, ntco } = require('../query-builders');
-
-const userHasRole = (role, profile) => profile.roles.some(r => r.type === role);
+const queryBuilder = require('../query-builders');
 
 module.exports = (taskflow) => {
   Case.db(taskflow.db);
@@ -12,40 +11,7 @@ module.exports = (taskflow) => {
     Promise.resolve()
       .then(() => {
         const profile = req.user.profile;
-        const userIsNtco = userHasRole('ntco', profile);
-        let query = Case.query();
-
-        req.query.progress = req.query.progress || 'outstanding';
-
-        switch (req.query.progress) {
-          case 'outstanding':
-            query.orWhere(builder => applicant.outstanding(builder, profile));
-
-            if (userIsNtco) {
-              query.orWhere(builder => ntco.outstanding(builder, profile));
-            }
-            break;
-
-          case 'in-progress':
-            query.orWhere(builder => applicant.inProgress(builder, profile));
-
-            if (userIsNtco) {
-              query.orWhere(builder => ntco.inProgress(builder, profile));
-            }
-            break;
-
-          case 'completed':
-            query.orWhere(builder => applicant.completed(builder, profile));
-
-            if (userIsNtco) {
-              query.orWhere(builder => ntco.completed(builder, profile));
-            }
-            break;
-        }
-
-        query = Case.orderBy({ query, sort: req.query.sort });
-        query = Case.paginate({ query, ...req.query });
-        return query;
+        return queryBuilder({ profile, ...req.query });
       })
       .then(cases => {
         const send = taskflow.responder(req, res);


### PR DESCRIPTION
Refactors the query builder to move the code out of the main router, and makes the calling of query builders by progress step a little less repetitive.

Adds default metadata in metadata hook to expand any task that has a related profile or establishment irrespective of type.

Adds query builders for ASRU users.