### PR TITLE
Add metadata to all tasks

### DIFF
--- a/lib/hooks/meta/default.js
+++ b/lib/hooks/meta/default.js
@@ -1,14 +1,10 @@
 const { get } = require('lodash');
 
 module.exports = (settings, model) => {
-  const action = get(model, 'data.action');
-  const data = get(model, 'data');
+  const data = get(model, 'data', {});
 
-  if (action === 'create') {
-    data.subject = get(data, 'data.profileId');
-    data.establishmentId = get(data, 'data.establishmentId');
-    return model.update(data);
-  }
+  data.subject = data.subject || get(data, 'data.profileId');
+  data.establishmentId = data.establishmentId || get(data, 'data.establishmentId');
 
-  return Promise.resolve();
+  return model.update(data);
 };


### PR DESCRIPTION
Currently metadata is only added to 'create' tasks, which is incorrect. We need metadata to be bound to all tasks.