### PR TITLE
Automatically move tasks that have been endorsed by NTCO

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -12,7 +12,8 @@ const hooks = {
   create: require('./hooks/create'),
   resolve: require('./hooks/resolve'),
   validateStatus: require('./hooks/validate/status'),
-  validatePayload: require('./hooks/validate/payload')
+  validatePayload: require('./hooks/validate/payload'),
+  autoForward: require('./hooks/auto-forward')
 };
 
 module.exports = settings => {
@@ -27,8 +28,9 @@ module.exports = settings => {
 
   flow.hook('create', hooks.meta(settings));
   flow.hook('create', hooks.create(settings));
-
   flow.hook(`status:*:${resubmitted.id}`, hooks.create(settings));
+
+  flow.hook(`status:*:*`, hooks.autoForward(settings));
 
   flow.hook(`pre-status:*:*`, hooks.validateStatus());
   flow.hook(`pre-status:*:*`, hooks.validatePayload());

--- a/lib/flow/index.js
+++ b/lib/flow/index.js
@@ -27,9 +27,10 @@ flow[resubmitted.id] = [withLicensing, withNtco];
 // ntco can endorse an application for the licensing team or ask for ammends from the applicant
 flow[withNtco.id] = [ntcoEndorsed, returnedToApplicant];
 
+flow[ntcoEndorsed.id] = [withLicensing];
+
 // licensing can return to applicant for ammends, refer to an inspector, grant or reject the licence
 flow[withLicensing.id] = [returnedToApplicant, referredToInspector, rejected, resolved];
-flow[ntcoEndorsed.id] = [returnedToApplicant, referredToInspector, rejected, resolved];
 flow[inspectorRecommended.id] = [returnedToApplicant, rejected, resolved];
 flow[inspectorRejected.id] = [returnedToApplicant, rejected, resolved];
 

--- a/lib/hooks/auto-forward/index.js
+++ b/lib/hooks/auto-forward/index.js
@@ -1,0 +1,21 @@
+const {
+  ntcoEndorsed,
+  withLicensing
+} = require('../../flow/status');
+
+module.exports = () => {
+  return model => {
+
+    switch (model.status) {
+
+      // all tasks endorsed by NTCO go to licensing
+      case ntcoEndorsed.id:
+        return model.setStatus(withLicensing.id);
+
+      default:
+        return Promise.resolve();
+
+    }
+
+  };
+};

--- a/test/integration/tasks/ntco.js
+++ b/test/integration/tasks/ntco.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const request = require('supertest');
 const workflowHelper = require('../../helpers/workflow');
 const { ntco } = require('../../data/profiles');
@@ -48,6 +49,27 @@ describe('NTCO', () => {
               }
             })
             .expect(200);
+        });
+    });
+
+    it('endorsing a pil application moves it to "with licensing"', () => {
+      return request(this.workflow)
+        .get('/')
+        .then(response => response.body.data.find(task => task.status === withNtco.id))
+        .then(task => {
+          return request(this.workflow)
+            .put(`/${task.id}/status`)
+            .send({
+              status: ntcoEndorsed.id,
+              meta: {
+                meta: {
+                  comment: 'endorsing a pil'
+                }
+              }
+            })
+            .expect(response => {
+              assert.equal(response.body.data.status, withLicensing.id);
+            });
         });
     });
 


### PR DESCRIPTION
Add a hook on ntco endorsement status change to shift the task immediately along to "with licensing". This allows for a decoupling between the UI options available and the subsequent stages.