### PR TITLE
Optimise decorators

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,10 +1,11 @@
 const Api = require('@asl/service/api');
 const Taskflow = require('@ukhomeoffice/taskflow');
-const decorator = require('./decorators');
 const schema = require('@asl/schema');
 const { resubmitted, autoResolved, resolved } = require('./flow/status');
 const tasksRouter = require('./router/tasks');
 const modelTasksRouter = require('./router/model-tasks');
+
+const decorators = require('./decorators');
 
 const profile = require('./middleware/profile');
 
@@ -27,7 +28,8 @@ module.exports = settings => {
 
   const flow = Taskflow({ db: settings.taskflowDB });
 
-  flow.decorate(decorator(settings));
+  flow.decorate(decorators.metadata(settings));
+  flow.decorate(decorators.nextSteps(settings), { list: false });
 
   flow.hook('pre-create', hooks.unique(settings));
 

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -1,35 +1,4 @@
-const Cacheable = require('./cacheable');
-const getNextStepsForUser = require('../flow/get-next-steps-for-user');
-
-module.exports = settings => {
-
-  const { Establishment, Profile } = settings.models;
-  const cache = Cacheable();
-
-  return (c, user) => {
-
-    const promises = [
-      c.data.establishmentId && cache.query(Establishment, c.data.establishmentId),
-      c.data.subject && cache.query(Profile, c.data.subject),
-      c.data.changedBy && cache.query(Profile, c.data.changedBy),
-      getNextStepsForUser(c, user.profile)
-    ];
-
-    return Promise.all(promises)
-      .then(([establishment, subject, changedBy, nextSteps]) => {
-        return {
-          ...c,
-          data: {
-            ...c.data,
-            establishment,
-            subject,
-            profile: subject,
-            changedBy
-          },
-          nextSteps
-        };
-      });
-
-  };
-
+module.exports = {
+  metadata: require('./metadata'),
+  nextSteps: require('./next-steps')
 };

--- a/lib/decorators/metadata.js
+++ b/lib/decorators/metadata.js
@@ -1,0 +1,32 @@
+const Cacheable = require('./cacheable');
+
+module.exports = settings => {
+
+  const { Establishment, Profile } = settings.models;
+  const cache = Cacheable();
+
+  return (c, user) => {
+
+    const promises = [
+      c.data.establishmentId && cache.query(Establishment, c.data.establishmentId),
+      c.data.subject && cache.query(Profile, c.data.subject),
+      c.data.changedBy && cache.query(Profile, c.data.changedBy)
+    ];
+
+    return Promise.all(promises)
+      .then(([establishment, subject, changedBy]) => {
+        return {
+          ...c,
+          data: {
+            ...c.data,
+            establishment,
+            subject,
+            profile: subject,
+            changedBy
+          }
+        };
+      });
+
+  };
+
+};

--- a/lib/decorators/next-steps.js
+++ b/lib/decorators/next-steps.js
@@ -1,0 +1,17 @@
+const getNextStepsForUser = require('../flow/get-next-steps-for-user');
+
+module.exports = settings => {
+
+  return (c, user) => {
+
+    return getNextStepsForUser(c, user.profile)
+      .then(nextSteps => {
+        return {
+          ...c,
+          nextSteps
+        };
+      });
+
+  };
+
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,9 +167,9 @@
       }
     },
     "@ukhomeoffice/taskflow": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/taskflow/-/taskflow-0.10.0.tgz",
-      "integrity": "sha512-ZHgTK7Kt4UEIekR38ucB3xmHJL6IoM/p//+PyZHDP2M9H+QrRjjQqnFa3FucrsH329CyQAWNzHLpOmQdnWGitQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/taskflow/-/taskflow-0.11.0.tgz",
+      "integrity": "sha512-Tfuwd4ul+06FBU/dCWIco4ThKZj+ffHKUwMI0W9pv3CHGigrj9lvhpm5tfoq07QuF81QPjVYhYPw9NNefB+IkA==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.3",
@@ -368,7 +368,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
@@ -632,27 +632,27 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -4510,7 +4510,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@asl/schema": "^7.4.3",
     "@asl/service": "^6.17.2",
-    "@ukhomeoffice/taskflow": "^0.10.0",
+    "@ukhomeoffice/taskflow": "^0.11.0",
     "aws-sdk": "^2.270.1",
     "express": "^4.16.4",
     "lodash": "^4.17.11",


### PR DESCRIPTION
Not all decorators need to be applied in list view (and involve potentially expensive data operations when applied to a list), so split the decorators into separate modules to be able to configure which are applied to lists, and which are only for single-task requests.