### PR TITLE
Don't destroy all the data when tasks resolve

### DIFF
--- a/lib/hooks/resolve/index.js
+++ b/lib/hooks/resolve/index.js
@@ -38,6 +38,6 @@ module.exports = settings => {
   return model => {
     return queue(model.data)
       .then(response => pollChangelog(response.MessageId))
-      .then(changelogModel => model.update({ id: changelogModel.modelId }));
+      .then(changelogModel => model.update({ ...model.data, id: changelogModel.modelId }));
   };
 };


### PR DESCRIPTION
`update` sets the data to whatever is passed, it is not a patch operation, so the full model needs to be set when updating or it destroys all the other data.