### PR TITLE
Handle the case where no user profile exists

### DIFF
--- a/lib/decorators/next-steps.js
+++ b/lib/decorators/next-steps.js
@@ -4,6 +4,10 @@ module.exports = settings => {
 
   return (c, user) => {
 
+    if (!user || !user.profile) {
+      return c;
+    }
+
     return getNextStepsForUser(c, user.profile)
       .then(nextSteps => {
         return {

--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -13,6 +13,13 @@ const asru = require('./asru');
 
 module.exports = ({ profile, sort = { column: 'updatedAt' }, limit, offset, progress = 'outstanding' }) => {
 
+  if (!profile) {
+    return Promise.resolve({
+      results: [],
+      count: 0
+    });
+  }
+
   if (!sort.ascending) {
     sort.ascending = progress !== 'completed';
   }


### PR DESCRIPTION
When a brand new user logs in for the first time then a profile does not exist in the database. We need to ensure that if this is the case then the call to create the new profile does not fail, and that a cal to get open tasks returns an empty list.