### PR TITLE
Don't use notifcations hook if it's not configured

### DIFF
--- a/lib/hooks/notify/index.js
+++ b/lib/hooks/notify/index.js
@@ -1,7 +1,9 @@
 const fetch = require('r2');
 
 module.exports = settings => json => {
-  fetch.post(settings.notifications, { json });
+  if (settings.notifications) {
+    fetch.post(settings.notifications, { json });
+  }
   // don't wait for a response, we don't want to block because notifcations failed
   return Promise.resolve();
 };


### PR DESCRIPTION
This just throws an error and makes a mess of the logs - in particular when running locally.