### PR TITLE
Use post-status hook for autoresolved tasks

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -49,8 +49,8 @@ module.exports = settings => {
 
   flow.hook('pre-status:*:*', hooks.validateStatus());
   flow.hook('pre-status:*:*', hooks.validatePayload());
-  flow.hook(`pre-status:*:${autoResolved.id}`, hooks.resolve(settings));
   flow.hook(`pre-status:*:${resolved.id}`, hooks.resolve(settings));
+  flow.hook(`status:*:${autoResolved.id}`, hooks.resolve(settings));
 
   app.use('/model-tasks', modelTasksRouter(flow));
   app.use('/', tasksRouter(flow));


### PR DESCRIPTION
Where a task autoresolves, but the resolver fails then it needs to stay resolved be cause there's no way for a user to retry the task. This means subsequent attempts to make the same change are blocked by the open (but invisible) task.

Switch from a pre-status hook to a post-status for autoresolved so the task will not stay open if resolution fails.