### PR TITLE
Don't consider "new" tasks to be open

### DIFF
--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -23,6 +23,7 @@ module.exports = settings => {
     return Case.query()
       .whereJsonSupersetOf('data', { id })
       .whereNotIn('status', closed())
+      .where('status', '!=', 'new')
       .then(results => {
         if (results && results.length) {
           throw new BadRequestError('There is an existing open task for this record');

--- a/lib/hooks/meta/index.js
+++ b/lib/hooks/meta/index.js
@@ -16,7 +16,7 @@ module.exports = settings => {
       const modelName = type === 'pil' ? type.toUpperCase() : ucFirst(type);
       const Model = settings.models[modelName];
       const modelData = await Model.query().findById(id);
-      data.modelData = modelData;
+      await model.update({ ...data, modelData });
     }
 
     switch (type) {
@@ -29,5 +29,6 @@ module.exports = settings => {
       default:
         return addDefaultMetadata(settings, model);
     }
+
   };
 };


### PR DESCRIPTION
Tasks only have a status of "new" if the create hook fails in some way to prevent them autoforwarding. If that happens then consider them to be closed so that they don't block subsequent attempts to raise tasks on that entity.

Also bundles a small refactor to make the `modelData` update explicit rather than relying on object property manipulation and a  downstream call to `update`.