### PR TITLE
Ensure getNextStepsForUser always returns a promise

### DIFF
--- a/lib/flow/get-next-steps-for-user.js
+++ b/lib/flow/get-next-steps-for-user.js
@@ -16,7 +16,7 @@ const userCreatedThisTask = (c, profile) => {
 
 module.exports = (c, profile) => {
   if (flow.autoForwards(c.status)) {
-    return flow.getNextSteps(c.status);
+    return Promise.resolve(flow.getNextSteps(c.status));
   }
 
   // if the task is outstanding for the current user then they can action it

--- a/lib/hooks/validate/status.js
+++ b/lib/hooks/validate/status.js
@@ -9,7 +9,8 @@ module.exports = () => {
     return Promise.resolve()
       .then(() => {
         return Promise.resolve()
-          .then(() => getNextStepsForUser(model, model.meta.user.profile).map(step => step.id))
+          .then(() => getNextStepsForUser(model, model.meta.user.profile))
+          .then(steps => steps.map(step => step.id))
           .then(validNextSteps => {
             if (!validNextSteps.includes(nextStatus)) {
               throw new BadRequestError('Invalid status change');


### PR DESCRIPTION
In some circumstances it was returning a plain array, which then threw an error when trying to `.then` it.