### PR TITLE
Establishment ids are stored as ints

### DIFF
--- a/lib/router/model-tasks.js
+++ b/lib/router/model-tasks.js
@@ -8,7 +8,7 @@ module.exports = taskflow => {
   Case.db(taskflow.db);
 
   router.param('modelId', (req, res, next, modelId) => {
-    req.modelId = modelId;
+    req.modelId = /^\d+$/.test(modelId) ? parseInt(modelId) : modelId;
     next();
   });
 

--- a/lib/router/model-tasks.js
+++ b/lib/router/model-tasks.js
@@ -8,7 +8,7 @@ module.exports = taskflow => {
   Case.db(taskflow.db);
 
   router.param('modelId', (req, res, next, modelId) => {
-    req.modelId = /^\d+$/.test(modelId) ? parseInt(modelId) : modelId;
+    req.modelId = /^\d+$/.test(modelId) ? parseInt(modelId, 10) : modelId;
     next();
   });
 


### PR DESCRIPTION
Establishments weren't returning any open tasks because the query was searching for a string id.