### PR TITLE
Store extra declaration options in task metadata

### DIFF
--- a/lib/hooks/update-data/project.js
+++ b/lib/hooks/update-data/project.js
@@ -1,9 +1,17 @@
 const { get, pick, size } = require('lodash');
 
 module.exports = (settings, model) => {
-  const authorisations = ['authority', 'awerb', 'ready'];
+  const declarations = [
+    'authority',
+    'awerb',
+    'ready',
+    'authority-pelholder-name',
+    'authority-endorsement-date',
+    'awerb-review-date',
+    'awerb-no-review-reason'
+  ];
   const meta = get(model, 'meta.payload.meta', {});
-  const updates = pick(meta, authorisations);
+  const updates = pick(meta, declarations);
 
   const version = get(model, 'meta.payload.meta.version', null);
   const data = get(model, 'data');


### PR DESCRIPTION
The declarations now reveal extra fields in some circumstances. Store that data against the task.