### PR TITLE
Pass a no-op patch method when autoresolving project version patch tasks

### DIFF
--- a/lib/middleware/resolve-project-version-updates.js
+++ b/lib/middleware/resolve-project-version-updates.js
@@ -7,7 +7,7 @@ module.exports = settings => {
     const model = get(req.body, 'model');
     const action = get(req.body, 'action');
     if (model === 'projectVersion' && (action === 'update' || action === 'patch')) {
-      return resolver({ data: req.body, update: noop })
+      return resolver({ data: req.body, update: noop, patch: noop })
         .then(() => res.json({}))
         .catch(next);
     }


### PR DESCRIPTION
We recycle the resolver hook to perform this task, which expects to receive a fully fleshed out task model as an argument and be able to call methods on it. This is not the case here, so we need to provide a stub method.