### PR TITLE
Use correct timestamps

### DIFF
--- a/lib/router/metrics.js
+++ b/lib/router/metrics.js
@@ -33,8 +33,9 @@ module.exports = taskflow => {
             type = `project-${isAmendment ? 'amendment' : 'application'}`;
           }
           const resubmissions = c.activityLog.filter(activity => get(activity, 'event.status') === 'resubmitted');
+          const closed = c.activityLog.find(activity => get(activity, 'event.status') === 'resolved');
           const iterations = resubmissions.length + 1;
-          return { type, iterations, createdAt: c.createdAt, updatedAt: c.updatedAt };
+          return { type, iterations, opened: c.createdAt, closed: closed.createdAt };
         });
       })
       .then(cases => {


### PR DESCRIPTION
The updatedAt timestamp doesn't actually work on tasks - it's always the same as the createdAt - so use the resolved event to get the closed timestamp for metrics.