### PR TITLE
Include licence holders tasks

### DIFF
--- a/lib/query-builders/applicant.js
+++ b/lib/query-builders/applicant.js
@@ -9,7 +9,8 @@ const {
 const isApplicant = profile => builder => {
   builder
     .whereJsonSupersetOf('data', { changedBy: profile.id })
-    .orWhereJsonSupersetOf('data', { subject: profile.id });
+    .orWhereJsonSupersetOf('data', { subject: profile.id })
+    .orWhereJsonSupersetOf('data:modelData', { licenceHolderId: profile.id });
 };
 
 module.exports = {


### PR DESCRIPTION
We were incorrectly setting the subject to the applicant meaning licence holders cannot action their own tasks.

This change ensures licence holders can see and action tasks to do with their own licences