### PR TITLE
Allow resubmissions to autoresolve

### DIFF
--- a/lib/flow/index.js
+++ b/lib/flow/index.js
@@ -22,13 +22,14 @@ const {
 const flow = {};
 
 flow[newCase.id] = [autoResolved, withNtco, withInspectorate, withLicensing];
+// resubmissions should follow the same rules as new submissions
+flow[resubmitted.id] = [...flow[newCase.id]];
 
 // applicant needs to make ammends and re-submit to licensing, or withdraw their application
 flow[returnedToApplicant.id] = [updated, resubmitted, discardedByApplicant];
-flow[recalledByApplicant.id] = [updated, resubmitted, discardedByApplicant];
+flow[recalledByApplicant.id] = [...flow[returnedToApplicant.id]];
 
 flow[updated.id] = [resubmitted];
-flow[resubmitted.id] = [withLicensing, withNtco, withInspectorate];
 
 // ntco can endorse an application for the licensing team or ask for ammends from the applicant
 flow[withNtco.id] = [ntcoEndorsed, returnedToApplicant];


### PR DESCRIPTION
Changing a profile amendment to no longer meet the criteria to raise a task results in an error because a resubmission cannot currently auto-resolve.

Reconfigure the allowed next steps to ensure resubmissions are always treated the same as new submissions.