### PR TITLE
Optimise decorator caching

### DIFF
--- a/lib/decorators/cacheable.js
+++ b/lib/decorators/cacheable.js
@@ -1,20 +1,22 @@
 module.exports = (settings = {}) => {
 
-  settings.ttl = settings.ttl || 60000;
+  settings.ttl = settings.ttl || 300000;
 
   const cache = {};
 
   const query = (Model, id) => {
     const key = `${Model.tableName}:${id}`;
     if (cache[key] && cache[key].updated + settings.ttl > Date.now()) {
-      return cache[key].result;
+      return Promise.resolve(cache[key].result);
     } else {
-      const result = Model.queryWithDeleted().findById(id);
-      cache[key] = {
-        updated: Date.now(),
-        result
-      };
-      return result;
+      return Model.queryWithDeleted().findById(id)
+        .then(result => {
+          cache[key] = {
+            updated: Date.now(),
+            result
+          };
+          return result;
+        });
     }
   };
 


### PR DESCRIPTION
The cache was storing the query object itself rather than the query result, which meant that subsequent requests to access the cached query caused re-execution, and therefore exactly no performance benefit.

By adding the result of the query rather than the query to the cache we can drastically improve performance of task lists.

Also increase the cache timeout to 5 mnutes from 1 minute.