### PR TITLE
Make cachable cache global

### DIFF
--- a/lib/decorators/cacheable.js
+++ b/lib/decorators/cacheable.js
@@ -1,34 +1,34 @@
 const cache = {};
 
+const clean = () => {
+  Object.keys(cache).forEach(key => {
+    if (cache[key].expires < Date.now()) {
+      delete cache[key];
+    }
+  });
+};
+
+setInterval(clean, 300000);
+
 module.exports = (settings = {}) => {
 
   settings.ttl = settings.ttl || 300000;
 
   const query = (Model, id) => {
     const key = `${Model.tableName}:${id}`;
-    if (cache[key] && cache[key].updated + settings.ttl > Date.now()) {
+    if (cache[key] && cache[key].expires > Date.now()) {
       return Promise.resolve(cache[key].result);
     } else {
       return Model.queryWithDeleted().findById(id)
         .then(result => {
           cache[key] = {
-            updated: Date.now(),
+            expires: Date.now() + settings.ttl,
             result
           };
           return result;
         });
     }
   };
-
-  const clean = () => {
-    Object.keys(cache).forEach(key => {
-      if (cache[key].updated + settings.ttl < Date.now()) {
-        delete cache[key];
-      }
-    });
-  };
-
-  setInterval(clean, 2 * settings.ttl);
 
   return { query };
 


### PR DESCRIPTION
Currently each separate instance of the `Cachable` uses its own cache store, which means that different decorators will potentially make the same query more than once.

Instead use a single cache store for all `Cachable` instances so repeated queries are eliminated.