### PR TITLE
Replace whereNotIn queries with a whereIn

### DIFF
--- a/lib/query-builders/admin.js
+++ b/lib/query-builders/admin.js
@@ -1,3 +1,6 @@
+const flow = require('../flow/status');
+const allStatuses = Object.values(flow).map(s => s.id);
+
 const {
   autoResolved,
   returnedToApplicant,
@@ -6,7 +9,7 @@ const {
   withdrawnByApplicant,
   recalledByApplicant,
   discardedByApplicant
-} = require('../flow/status');
+} = flow;
 
 const buildEstablishmentQuery = profile => {
   return builder => {
@@ -29,17 +32,18 @@ module.exports = {
   },
 
   inProgress: (queryBuilder, profile) => {
+    const nopes = [
+      autoResolved.id,
+      resolved.id,
+      rejected.id,
+      withdrawnByApplicant.id,
+      returnedToApplicant.id,
+      recalledByApplicant.id,
+      discardedByApplicant.id
+    ];
     queryBuilder
       .where(buildEstablishmentQuery(profile))
-      .whereNotIn('status', [
-        autoResolved.id,
-        resolved.id,
-        rejected.id,
-        withdrawnByApplicant.id,
-        returnedToApplicant.id,
-        recalledByApplicant.id,
-        discardedByApplicant.id
-      ]);
+      .whereIn('status', allStatuses.filter(s => !nopes.includes(s)));
   },
 
   completed: (queryBuilder, profile) => {

--- a/lib/query-builders/applicant.js
+++ b/lib/query-builders/applicant.js
@@ -1,3 +1,6 @@
+const flow = require('../flow/status');
+const allStatuses = Object.values(flow).map(s => s.id);
+
 const {
   autoResolved,
   returnedToApplicant,
@@ -6,7 +9,7 @@ const {
   rejected,
   withdrawnByApplicant,
   discardedByApplicant
-} = require('../flow/status');
+} = flow;
 
 const isApplicant = profile => builder => {
   builder
@@ -36,17 +39,18 @@ module.exports = {
   },
 
   inProgress: (queryBuilder, profile) => {
+    const nopes = [
+      autoResolved.id,
+      resolved.id,
+      rejected.id,
+      withdrawnByApplicant.id,
+      discardedByApplicant.id,
+      returnedToApplicant.id,
+      recalledByApplicant.id
+    ];
     queryBuilder
       .where(isApplicant(profile))
-      .whereNotIn('status', [
-        autoResolved.id,
-        resolved.id,
-        rejected.id,
-        withdrawnByApplicant.id,
-        discardedByApplicant.id,
-        returnedToApplicant.id,
-        recalledByApplicant.id
-      ]);
+      .whereIn('status', allStatuses.filter(s => !nopes.includes(s)));
   },
 
   completed: (queryBuilder, profile) => {

--- a/lib/query-builders/ntco.js
+++ b/lib/query-builders/ntco.js
@@ -1,3 +1,6 @@
+const flow = require('../flow/status');
+const allStatuses = Object.values(flow).map(s => s.id);
+
 const {
   withNtco,
   autoResolved,
@@ -6,7 +9,8 @@ const {
   withdrawnByApplicant,
   recalledByApplicant,
   discardedByApplicant
-} = require('../flow/status');
+} = flow;
+
 const { getEstablishmentsWhereUserIsRole } = require('../util');
 
 const buildEstablishmentQuery = profile => {
@@ -28,18 +32,19 @@ module.exports = {
   },
 
   inProgress: (queryBuilder, profile) => {
+    const nopes = [
+      withNtco.id,
+      autoResolved.id,
+      resolved.id,
+      rejected.id,
+      withdrawnByApplicant.id,
+      discardedByApplicant.id,
+      recalledByApplicant.id
+    ];
     queryBuilder
       .where(buildEstablishmentQuery(profile))
       .whereJsonSupersetOf('data', { model: 'pil', action: 'grant' })
-      .whereNotIn('status', [
-        withNtco.id,
-        autoResolved.id,
-        resolved.id,
-        rejected.id,
-        withdrawnByApplicant.id,
-        discardedByApplicant.id,
-        recalledByApplicant.id
-      ]);
+      .whereIn('status', allStatuses.filter(s => !nopes.includes(s)));
   },
 
   completed: (queryBuilder, profile) => {


### PR DESCRIPTION
The `whereNotIn` clause in a query can't hit the database indexes on the status column and so the queries run far slower than other task-list queries.

Replace the `whereNotIn` with a `whereIn` used in conjunction with a filter against a list of excluded statuses so that the indexes are used for the query.