### PR TITLE
Apply whereNotIn optimisation to model tasks

### DIFF
--- a/lib/flow/index.js
+++ b/lib/flow/index.js
@@ -69,6 +69,11 @@ const closed = () => {
   return values(statuses).map(s => s.id).filter(s => !flow[s] || !flow[s].length);
 };
 
+const open = () => {
+  const nopes = closed();
+  return values(statuses).map(s => s.id).filter(s => !nopes.includes(s));
+};
+
 const withASRU = () => {
   return values(statuses).filter(s => s.withASRU === true).map(s => s.id);
 };
@@ -80,6 +85,7 @@ const editable = () => {
 module.exports = {
   flow,
   closed,
+  open,
   getAllSteps,
   getNextSteps,
   autoForwards,

--- a/lib/router/model-tasks.js
+++ b/lib/router/model-tasks.js
@@ -1,6 +1,6 @@
 const { Router } = require('express');
 const Case = require('@ukhomeoffice/taskflow/lib/models/case');
-const { closed } = require('../flow');
+const { open } = require('../flow');
 
 module.exports = taskflow => {
   const router = Router({ mergeParams: true });
@@ -18,7 +18,7 @@ module.exports = taskflow => {
       .then(() => {
         return Case.query()
           .whereJsonSupersetOf('data', { id: req.modelId })
-          .whereNotIn('status', closed());
+          .whereIn('status', open());
       })
       .then(cases => {
         const end = process.hrtime(start);


### PR DESCRIPTION
Using `whereNotIn` prevents using indexes for the database query, so it runs slowly. Invert the status list and use a `whereIn` instead.