### PR TITLE
Filter comments from activity log

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -47,7 +47,8 @@ module.exports = settings => {
 
   flow.decorate(decorators.metadata(settings));
   flow.decorate(decorators.deadline(settings));
-  flow.decorate(decorators.comments(settings), { list: false });
+  flow.decorate(decorators.filterComments(settings), { list: false });
+  flow.decorate(decorators.deleteComments(settings), { list: false });
   flow.decorate(decorators.activityLog(settings), { list: false });
   flow.decorate(decorators.nextSteps(settings), { list: false });
   flow.decorate(decorators.licenceHolder(settings), { list: false });

--- a/lib/api.js
+++ b/lib/api.js
@@ -47,6 +47,7 @@ module.exports = settings => {
 
   flow.decorate(decorators.metadata(settings));
   flow.decorate(decorators.deadline(settings));
+  flow.decorate(decorators.comments(settings), { list: false });
   flow.decorate(decorators.activityLog(settings), { list: false });
   flow.decorate(decorators.nextSteps(settings), { list: false });
   flow.decorate(decorators.licenceHolder(settings), { list: false });

--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -10,14 +10,6 @@ module.exports = settings => {
       return c;
     }
 
-    const deletedComments = c.activityLog.filter(log => log.eventName === 'delete-comment').map(log => log.event.meta.id);
-
-    deletedComments.forEach(id => {
-      const log = c.activityLog.find(log => log.id === id);
-      log.deleted = true;
-      log.comment = null;
-    });
-
     const promises = c.activityLog.map(log => cache.query(Profile, log.changedBy));
 
     return Promise.all(promises)

--- a/lib/decorators/delete-comments.js
+++ b/lib/decorators/delete-comments.js
@@ -1,0 +1,32 @@
+module.exports = settings => {
+
+  return (c, user) => {
+    if (!c.activityLog) {
+      return c;
+    }
+
+    const deletedComments = c.activityLog.filter(log => log.eventName === 'delete-comment').map(log => log.event.meta.id);
+
+    const activityLog = c.activityLog
+      .map(activity => {
+        if (activity.eventName === 'comment' && deletedComments.includes(activity.id)) {
+          return {
+            ...activity,
+            deleted: true,
+            comment: null
+          };
+        }
+        return activity;
+      })
+      .filter(activity => {
+        return activity.eventName !== 'delete-comment';
+      });
+
+    return {
+      ...c,
+      activityLog
+    };
+
+  };
+
+};

--- a/lib/decorators/filter-comments.js
+++ b/lib/decorators/filter-comments.js
@@ -5,8 +5,6 @@ module.exports = settings => {
       return c;
     }
 
-    const deletedComments = c.activityLog.filter(log => log.eventName === 'delete-comment').map(log => log.event.meta.id);
-
     const statusChanges = c.activityLog
       .filter(a => a.eventName.match(/^status:/))
       .sort((a, b) => {
@@ -59,16 +57,6 @@ module.exports = settings => {
           return {
             ...activity,
             isNew: isNew(activity)
-          };
-        }
-        return activity;
-      })
-      .map(activity => {
-        if (activity.eventName === 'comment' && deletedComments.includes(activity.id)) {
-          return {
-            ...activity,
-            deleted: true,
-            comment: null
           };
         }
         return activity;

--- a/lib/decorators/filter-comments.js
+++ b/lib/decorators/filter-comments.js
@@ -1,0 +1,84 @@
+module.exports = settings => {
+
+  return (c, user) => {
+    if (!c.activityLog) {
+      return c;
+    }
+
+    const deletedComments = c.activityLog.filter(log => log.eventName === 'delete-comment').map(log => log.event.meta.id);
+
+    const statusChanges = c.activityLog
+      .filter(a => a.eventName.match(/^status:/))
+      .sort((a, b) => {
+        // sort into ascending order by time
+        return a.createdAt < b.createdAt ? -1 : 1;
+      });
+
+    const getLastEvent = fn => {
+      return statusChanges.reduceRight((time, activity) => {
+        if (time) {
+          return time;
+        }
+        if (fn(activity)) {
+          return activity.createdAt;
+        }
+      }, null);
+    };
+
+    const lastSubmit = getLastEvent(s => s.event.status === 'resubmitted') || c.createdAt;
+    const lastASRUAction = getLastEvent(s => s.event.meta.user.profile.asruUser) || c.createdAt;
+
+    const isVisible = comment => {
+      if (comment.eventName !== 'comment') {
+        return true;
+      }
+      const timestamp = comment.createdAt;
+
+      if (user.profile.asruUser === comment.event.meta.user.profile.asruUser) {
+        return true;
+      }
+
+      if (user.profile.asruUser) {
+        return timestamp < lastSubmit;
+      } else {
+        return timestamp < lastASRUAction;
+      }
+
+    };
+
+    const isNew = comment => {
+      return user.profile.asruUser ? comment.createdAt > lastASRUAction : comment.createdAt > lastSubmit;
+    };
+
+    const activityLog = c.activityLog
+      .filter(activity => {
+        return activity.eventName !== 'comment' || isVisible(activity);
+      })
+      .map(activity => {
+        if (activity.eventName === 'comment') {
+          return {
+            ...activity,
+            isNew: isNew(activity)
+          };
+        }
+        return activity;
+      })
+      .map(activity => {
+        if (activity.eventName === 'comment' && deletedComments.includes(activity.id)) {
+          return {
+            ...activity,
+            deleted: true,
+            comment: null
+          };
+        }
+        return activity;
+      });
+
+    return {
+      ...c,
+      activityLog
+    };
+
+  };
+
+};

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -3,5 +3,6 @@ module.exports = {
   metadata: require('./metadata'),
   nextSteps: require('./next-steps'),
   licenceHolder: require('./licence-holder'),
-  deadline: require('./deadline')
+  deadline: require('./deadline'),
+  comments: require('./filter-comments')
 };

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -4,5 +4,6 @@ module.exports = {
   nextSteps: require('./next-steps'),
   licenceHolder: require('./licence-holder'),
   deadline: require('./deadline'),
-  comments: require('./filter-comments')
+  filterComments: require('./filter-comments'),
+  deleteComments: require('./delete-comments')
 };

--- a/test/unit/decorators/delete-comments.js
+++ b/test/unit/decorators/delete-comments.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+
+const decorator = require('../../../lib/decorators/delete-comments');
+
+describe('Comment deletion', () => {
+
+  let task;
+
+  beforeEach(() => {
+    task = {
+      status: 'with-inspectorate',
+      withASRU: true,
+      createdAt: '2019-09-20T10:00:00.000Z',
+      activityLog: [
+        {
+          id: '1',
+          eventName: 'create',
+          createdAt: '2019-09-20T10:00:00.000Z'
+        },
+        {
+          id: '2',
+          eventName: 'status:new:with-inspectorate',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        },
+        {
+          id: '3',
+          eventName: 'comment',
+          comment: 'foo',
+          createdAt: '2019-09-20T11:00:00.000Z'
+        },
+        {
+          id: '4',
+          eventName: 'comment',
+          comment: 'bar',
+          createdAt: '2019-09-20T12:00:00.000Z'
+        },
+        {
+          id: '5',
+          eventName: 'delete-comment',
+          comment: 'bar',
+          event: {
+            meta: { id: '3' }
+          },
+          createdAt: '2019-09-20T12:00:00.000Z'
+        }
+      ]
+    };
+  });
+
+  it('removes deleted comments from the activity log', () => {
+    const result = decorator()(task);
+    assert.equal(result.activityLog.length, 4);
+
+    const comments = result.activityLog.filter(a => a.eventName === 'comment');
+    assert.equal(comments.length, 2);
+    assert.equal(comments[0].comment, null);
+    assert.equal(comments[0].deleted, true);
+    assert.equal(comments[1].comment, 'bar');
+
+    const deleted = result.activityLog.filter(a => a.eventName === 'delete-comment');
+    assert.equal(deleted.length, 0);
+  });
+
+});

--- a/test/unit/decorators/filter-comments.js
+++ b/test/unit/decorators/filter-comments.js
@@ -1,0 +1,206 @@
+const assert = require('assert');
+
+const flow = require('../../../lib/flow');
+const decorator = require('../../../lib/decorators/filter-comments');
+
+const History = () => {
+
+  const model = {
+    status: 'new',
+    withASRU: false,
+    createdAt: '2019-09-20T10:00:00.000Z',
+    activityLog: [
+      { eventName: 'create', createdAt: '2019-09-20T10:00:00.000Z' }
+    ]
+  };
+
+  const timestamp = () => {
+    const count = model.activityLog.length;
+    return count < 10 ? `2019-09-20T10:00:0${count}.000Z` : `2019-09-20T10:00:${count}.000Z`;
+  };
+
+  return {
+    status: (status, user) => {
+      model.activityLog.push({
+        eventName: `status:${model.status}:${status}`,
+        event: { status, meta: { user } },
+        createdAt: timestamp()
+      });
+      model.status = status;
+      model.withASRU = flow.withASRU().includes(status);
+    },
+    comment: (comment, user) => {
+      model.activityLog.push({
+        eventName: 'comment',
+        comment,
+        event: { meta: { user } },
+        createdAt: timestamp()
+      });
+    },
+    model
+  };
+
+};
+
+const users = {
+  asru: { profile: { asruUser: true } },
+  external: { profile: { asruUser: false } }
+};
+
+const assertComments = (task, user, expected) => {
+  const result = decorator()(task.model, user);
+  const comments = result.activityLog.filter(a => a.eventName === 'comment');
+  assert.equal(comments.length, expected.length);
+  assert.deepEqual(comments.map(c => c.comment), expected);
+};
+
+describe('Comment filtering', () => {
+
+  describe('when task is with inspectorate', () => {
+
+    let task;
+
+    beforeEach(() => {
+      task = History();
+      task.status('with-inspectorate', users.external);
+      task.comment('one', users.asru);
+      task.comment('two', users.asru);
+    });
+
+    it('comments made post-submission are not visible to external users', () => {
+      assertComments(task, users.external, []);
+    });
+
+    it('all comments are visible to asru users', () => {
+      assertComments(task, users.asru, ['one', 'two']);
+    });
+
+  });
+
+  describe('when task is returned to applicant', () => {
+
+    let task;
+
+    beforeEach(() => {
+      task = History();
+      task.status('with-inspectorate', users.external);
+      task.comment('one', users.asru);
+      task.comment('two', users.asru);
+      task.status('returned-to-applicant', users.asru);
+      task.comment('three', users.external);
+    });
+
+    it('all comments are visible to external users', () => {
+      assertComments(task, users.external, ['one', 'two', 'three']);
+    });
+
+    it('comments made post-return are not visible to asru users', () => {
+      assertComments(task, users.asru, ['one', 'two']);
+    });
+
+  });
+
+  describe('when task is recalled by the applicant', () => {
+
+    let task;
+
+    beforeEach(() => {
+      task = History();
+      task.status('with-inspectorate', users.external);
+      task.comment('one', users.asru);
+      task.comment('two', users.asru);
+      task.status('recalled-by-applicant', users.external);
+      task.comment('three', users.external);
+    });
+
+    it('only comment made post-recall is visible to external users', () => {
+      assertComments(task, users.external, ['three']);
+    });
+
+    it('only comments made pre-recall are visible to asru users', () => {
+      assertComments(task, users.asru, ['one', 'two']);
+    });
+  });
+
+  describe('when task is recalled and then resubmitted', () => {
+
+    let task;
+
+    beforeEach(() => {
+      task = History();
+      task.status('with-inspectorate', users.external);
+      task.comment('one', users.asru);
+      task.comment('two', users.asru);
+      task.status('recalled-by-applicant', users.external);
+      task.comment('three', users.external);
+      task.status('resubmitted', users.external);
+      task.status('with-inspectorate', users.external);
+      task.comment('four', users.asru);
+    });
+
+    it('only comment made post-recall is visible to external users', () => {
+      assertComments(task, users.external, ['three']);
+    });
+
+    it('all comments are now visible to asru users', () => {
+      assertComments(task, users.asru, ['one', 'two', 'three', 'four']);
+    });
+
+  });
+
+  describe('when task is recalled, resubmitted, and then discarded', () => {
+
+    let task;
+
+    beforeEach(() => {
+      task = History();
+      task.status('with-inspectorate', users.external);
+      task.comment('one', users.asru);
+      task.comment('two', users.asru);
+      task.status('recalled-by-applicant', users.external);
+      task.comment('three', users.external);
+      task.status('resubmitted', users.external);
+      task.status('with-inspectorate', users.external);
+      task.comment('four', users.asru);
+      task.status('discarded-by-applicant', users.external);
+    });
+
+    it('only comment made post-recall is visible to external users', () => {
+      assertComments(task, users.external, ['three']);
+    });
+
+    it('all comments are now visible to asru users', () => {
+      assertComments(task, users.asru, ['one', 'two', 'three', 'four']);
+    });
+
+  });
+
+  describe('when task is recalled, resubmitted, and then returned', () => {
+
+    let task;
+
+    beforeEach(() => {
+      task = History();
+      task.status('with-inspectorate', users.external);
+      task.comment('one', users.asru);
+      task.comment('two', users.asru);
+      task.status('recalled-by-applicant', users.external);
+      task.comment('three', users.external);
+      task.status('resubmitted', users.external);
+      task.status('with-inspectorate', users.external);
+      task.comment('four', users.asru);
+      task.status('returned-to-applicant', users.asru);
+      task.comment('five', users.external);
+    });
+
+    it('all comments are now visible to external users', () => {
+      assertComments(task, users.external, ['one', 'two', 'three', 'four', 'five']);
+    });
+
+    it('all comments are now visible to asru users except those made post return', () => {
+      assertComments(task, users.asru, ['one', 'two', 'three', 'four']);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Removes comments based on the user role, the commenter's role and time relative to particular events. Users can always see comments made by people of the same "type" as them (i.e. ASRU or not-ASRU). For ASRU users viewing external comments they only become visible post-submission. For external users viewing ASRU comments they only become visible after an ASRU instigated status change.

Also moves the comment deletion code into here because it makes more sense.