### PR TITLE
Reduce amount of data returned by metrics query

### DIFF
--- a/lib/router/metrics.js
+++ b/lib/router/metrics.js
@@ -15,6 +15,9 @@ module.exports = (taskflow, settings) => {
       .then(() => {
         return Case.query()
           .eager('[activityLog]')
+          .modifyEager('[activityLog]', builder => {
+            builder.select('eventName').where('eventName', 'ilike', 'status:%:returned-to-applicant');
+          })
           .where('updated_at', '>', since)
           .where({ status: 'resolved' });
       })
@@ -29,10 +32,8 @@ module.exports = (taskflow, settings) => {
             const isAmendment = get(c, 'data.modelData.status') !== 'inactive';
             type = `project-${isAmendment ? 'amendment' : 'application'}`;
           }
-          const resubmissions = c.activityLog.filter(activity => get(activity, 'event.status') === 'resubmitted');
-          const closed = c.activityLog.find(activity => get(activity, 'event.status') === 'resolved');
-          const iterations = resubmissions.length + 1;
-          return { type, iterations, opened: c.createdAt, closed: closed.createdAt };
+          const iterations = c.activityLog.length + 1;
+          return { type, iterations };
         });
       });
   };


### PR DESCRIPTION
We only need to get the number of returns in the activity log, not load the entire log into memory. Optimise the query to create a far smaller dataset.