### PR TITLE
Include establishment tasks in establishment filter

### DIFF
--- a/lib/query-builders/admin.js
+++ b/lib/query-builders/admin.js
@@ -1,3 +1,4 @@
+const filterToEstablishments = require('./filter-to-establishments');
 const flow = require('../flow/status');
 const allStatuses = Object.values(flow).map(s => s.id);
 
@@ -12,9 +13,8 @@ const {
 } = flow;
 
 const buildEstablishmentQuery = profile => {
-  return builder => {
-    builder.whereJsonSubsetOf('data:establishmentId', profile.establishments.filter(e => e.role === 'admin').map(e => e.id));
-  };
+  const establishments = profile.establishments.filter(e => e.role === 'admin').map(e => e.id);
+  return filterToEstablishments(establishments);
 };
 
 module.exports = {

--- a/lib/query-builders/filter-to-establishments.js
+++ b/lib/query-builders/filter-to-establishments.js
@@ -1,0 +1,9 @@
+module.exports = establishments => builder => {
+  builder
+    .whereJsonSubsetOf('data:establishmentId', establishments)
+    .orWhere(builder => {
+      builder
+        .whereJsonSupersetOf('data', { model: 'establishment' })
+        .whereJsonSubsetOf('data:id', establishments);
+    });
+};

--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -1,6 +1,8 @@
 const isUndefined = require('lodash/isUndefined');
 const Case = require('@ukhomeoffice/taskflow/lib/models/case');
 
+const filterToEstablishments = require('./filter-to-establishments');
+
 const userHasNamedRole = (role, profile) => profile.roles.some(r => r.type === role);
 const userHasPermission = (role, profile) => profile.establishments.some(e => e.role === role);
 
@@ -26,11 +28,12 @@ const buildQuery = (progress, profile) => {
 
   if (!profile.asruUser) {
     query.andWhere(builder => {
+      const establishments = profile.establishments.map(e => e.id);
       // make sure we only return tasks where the user is currently associated with the establishment
       // (except for profile tasks which don't have an association)
       builder
         .whereJsonSupersetOf('data', { model: 'profile' })
-        .orWhereJsonSubsetOf('data:establishmentId', profile.establishments.map(e => e.id));
+        .orWhere(filterToEstablishments(establishments));
     });
   }
 

--- a/lib/query-builders/ntco.js
+++ b/lib/query-builders/ntco.js
@@ -1,3 +1,4 @@
+const filterToEstablishments = require('./filter-to-establishments');
 const flow = require('../flow/status');
 const allStatuses = Object.values(flow).map(s => s.id);
 
@@ -14,13 +15,8 @@ const {
 const { getEstablishmentsWhereUserIsRole } = require('../util');
 
 const buildEstablishmentQuery = profile => {
-  return builder => {
-    getEstablishmentsWhereUserIsRole('ntco', profile)
-      .forEach(establishmentId => {
-        // not sure if you can do a WHERE IN with the json queries, so just OR each establishment
-        builder.orWhereJsonSupersetOf('data', { establishmentId });
-      });
-  };
+  const establishments = getEstablishmentsWhereUserIsRole('ntco', profile);
+  return filterToEstablishments(establishments);
 };
 
 module.exports = {

--- a/test/integration/task-lists/establishment-admin.js
+++ b/test/integration/task-lists/establishment-admin.js
@@ -29,7 +29,7 @@ describe('Establishment Admin', () => {
   describe('outstanding tasks', () => {
 
     it('sees tasks for their establishment that require action', () => {
-      const expected = [ 'pil returned', 'Submitted by HOLC', 'recalled ppl' ];
+      const expected = [ 'pil returned', 'Submitted by HOLC', 'recalled ppl', 'conditions update' ];
       return request(this.workflow)
         .get('/')
         .expect(200)


### PR DESCRIPTION
Because these do not get an `establishmentId` property set then they need a separate query clause to be able to be included in the establishment filter.

Refactor slightly to make this query a standard component.