### PR TITLE
Handle decorating cases with anonymous status changes

### DIFF
--- a/lib/decorators/filter-comments.js
+++ b/lib/decorators/filter-comments.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash');
+
 module.exports = settings => {
 
   return (c, user) => {
@@ -24,7 +26,7 @@ module.exports = settings => {
     };
 
     const lastSubmit = getLastEvent(s => s.event.status === 'resubmitted') || c.createdAt;
-    const lastASRUAction = getLastEvent(s => s.event.meta.user.profile.asruUser) || c.createdAt;
+    const lastASRUAction = getLastEvent(s => get(s, 'event.meta.user.profile.asruUser', false)) || c.createdAt;
 
     const isVisible = comment => {
       if (comment.eventName !== 'comment') {

--- a/test/unit/decorators/filter-comments.js
+++ b/test/unit/decorators/filter-comments.js
@@ -43,6 +43,7 @@ const History = () => {
 };
 
 const users = {
+  anon: { },
   asru: { profile: { asruUser: true } },
   external: { profile: { asruUser: false } }
 };
@@ -199,6 +200,17 @@ describe('Comment filtering', () => {
 
     it('all comments are now visible to asru users except those made post return', () => {
       assertComments(task, users.asru, ['one', 'two', 'three', 'four']);
+    });
+
+  });
+
+  describe('when a task is an autoresolved profile creation - bugfix', () => {
+
+    it('doesn\'t throw as a result of status changes with no user profile', () => {
+      const task = History();
+      task.status('autoresolved', users.anon);
+
+      assertComments(task, users.anon, []);
     });
 
   });


### PR DESCRIPTION
The task that is created to create a new profile for a user does not have a profile attached, so if the decorator attempts to read properties from the profile on that task's activity then it throws errors.

Use `get` instead of direct property access to handle this case.