### PR TITLE
Don't add deadline property to recalled tasks

### DIFF
--- a/lib/decorators/deadline.js
+++ b/lib/decorators/deadline.js
@@ -1,6 +1,7 @@
 const { get } = require('lodash');
 const moment = require('moment-business-time');
 const Case = require('@ukhomeoffice/taskflow/lib/models/case');
+const { withASRU } = require('../flow');
 
 const hasActiveDeadline = c => {
   const model = get(c, 'data.model');
@@ -8,7 +9,7 @@ const hasActiveDeadline = c => {
   const status = get(c, 'status');
   const isAmendment = get(c, 'data.modelData.status') !== 'inactive';
 
-  if (model !== 'project' || action !== 'grant' || status === 'returned-to-applicant' || isAmendment) {
+  if (model !== 'project' || action !== 'grant' || !withASRU().includes(status) || isAmendment) {
     return false;
   }
 
@@ -22,13 +23,19 @@ const declarationConfirmed = declaration => declaration && declaration.toLowerCa
 module.exports = settings => {
   return c => {
     if (!hasActiveDeadline(c)) {
-      return c;
+      return Promise.resolve(c);
     }
 
     return Promise.resolve()
-      .then(() => Case.find(c.id))
+      .then(() => {
+        if (!c.activityLog) {
+          return Case.find(c.id)
+            .then(model => model.toJSON());
+        }
+        return c;
+      })
       .then(model => {
-        const lastSubmitted = model._activityLog.reduceRight((lastSubmission, activity) => {
+        const lastSubmitted = model.activityLog.reduceRight((lastSubmission, activity) => {
           const status = activity.eventName.split(':').pop();
           return status === 'resubmitted' ? activity.createdAt : lastSubmission;
         }, c.createdAt);

--- a/test/unit/decorators/deadline.js
+++ b/test/unit/decorators/deadline.js
@@ -1,0 +1,176 @@
+const assert = require('assert');
+
+const decorator = require('../../../lib/decorators/deadline');
+
+describe('Deadline', () => {
+
+  it('does not set a deadline on recalled tasks', () => {
+    const task = {
+      status: 'recalled',
+      createdAt: '2019-09-20T10:00:00.000Z',
+      data: {
+        model: 'project',
+        action: 'grant',
+        modelData: {
+          status: 'inactive'
+        },
+        meta: {
+          authority: 'yes',
+          awerb: 'yes',
+          ready: 'yes'
+        }
+      },
+      activityLog: [
+        {
+          eventName: 'create',
+          createdAt: '2019-09-20T10:00:00.000Z'
+        },
+        {
+          eventName: 'status:new:with-inspectorate',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        },
+        {
+          eventName: 'status:with-inspectorate:recalled',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        }
+      ]
+    };
+    return decorator()(task).then(result => {
+      assert.ok(!result.deadline);
+    });
+  });
+
+  it('does not set a deadline on returned tasks', () => {
+    const task = {
+      status: 'returned-to-applicant',
+      createdAt: '2019-09-20T10:00:00.000Z',
+      data: {
+        model: 'project',
+        action: 'grant',
+        modelData: {
+          status: 'inactive'
+        },
+        meta: {
+          authority: 'yes',
+          awerb: 'yes',
+          ready: 'yes'
+        }
+      },
+      activityLog: [
+        {
+          eventName: 'create',
+          createdAt: '2019-09-20T10:00:00.000Z'
+        },
+        {
+          eventName: 'status:new:with-inspectorate',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        },
+        {
+          eventName: 'status:with-inspectorate:returned-to-applicant',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        }
+      ]
+    };
+    return decorator()(task).then(result => {
+      assert.ok(!result.deadline);
+    });
+  });
+
+  it('does not set a deadline on tasks with incomplete declarations', () => {
+    const task = {
+      status: 'with-inspectorate',
+      createdAt: '2019-09-20T10:00:00.000Z',
+      data: {
+        model: 'project',
+        action: 'grant',
+        modelData: {
+          status: 'inactive'
+        },
+        meta: {
+          authority: 'yes',
+          awerb: 'yes',
+          ready: 'no'
+        }
+      },
+      activityLog: [
+        {
+          eventName: 'create',
+          createdAt: '2019-09-20T10:00:00.000Z'
+        },
+        {
+          eventName: 'status:new:with-inspectorate',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        }
+      ]
+    };
+    return decorator()(task).then(result => {
+      assert.ok(!result.deadline);
+    });
+  });
+
+  it('does not set a deadline on amendment tasks', () => {
+    const task = {
+      status: 'with-inspectorate',
+      createdAt: '2019-09-20T10:00:00.000Z',
+      data: {
+        model: 'project',
+        action: 'grant',
+        modelData: {
+          status: 'active'
+        },
+        meta: {
+          authority: 'yes',
+          awerb: 'yes',
+          ready: 'yes'
+        }
+      },
+      activityLog: [
+        {
+          eventName: 'create',
+          createdAt: '2019-09-20T10:00:00.000Z'
+        },
+        {
+          eventName: 'status:new:with-inspectorate',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        }
+      ]
+    };
+    return decorator()(task).then(result => {
+      assert.ok(!result.deadline);
+    });
+  });
+
+  it('sets a deadline on complete applications with ASRU', () => {
+    const task = {
+      status: 'with-inspectorate',
+      createdAt: '2019-09-20T10:00:00.000Z',
+      data: {
+        model: 'project',
+        action: 'grant',
+        modelData: {
+          status: 'inactive'
+        },
+        meta: {
+          authority: 'yes',
+          awerb: 'yes',
+          ready: 'yes'
+        }
+      },
+      activityLog: [
+        {
+          eventName: 'create',
+          createdAt: '2019-09-20T10:00:00.000Z'
+        },
+        {
+          eventName: 'status:new:with-inspectorate',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        }
+      ]
+    };
+    return decorator()(task).then(result => {
+      assert.ok(result.deadline);
+      assert.equal(result.deadline.format('YYYY-MM-DD'), '2019-11-15');
+    });
+  });
+
+});


### PR DESCRIPTION
When recalled was added to the possible statuses it wasn't considered in the parameters that prevent tasks from having a deadline.