### PR TITLE
Don't send ASRU initiated PIL amendments to NTCO

### DIFF
--- a/lib/hooks/create/pil.js
+++ b/lib/hooks/create/pil.js
@@ -3,44 +3,35 @@ const { BadRequestError } = require('@asl/service/errors');
 const { autoResolved, awaitingEndorsement, withLicensing } = require('../../flow/status');
 
 module.exports = settings => {
-  const { Profile } = settings.models;
   return model => {
     const action = get(model, 'data.action');
-    const changedBy = get(model, 'data.changedBy');
+    const profile = get(model, 'meta.user.profile', {});
+    const isAmendment = get(model, 'data.modelData.status') === 'active';
 
     switch (action) {
       case 'update-conditions':
-        return Promise.resolve()
-          .then(() => Profile.query().findById(changedBy))
-          .then(profile => {
-            if (!profile.asruUser) {
-              throw new BadRequestError('Only ASRU users can update licence conditions');
-            }
-            return profile;
-          })
-          .then(profile => {
-            if (profile.asruLicensing) {
-              return model.setStatus(autoResolved.id);
-            } else {
-              return model.setStatus(withLicensing.id);
-            }
-          });
+        if (!profile.asruUser) {
+          throw new BadRequestError('Only ASRU users can update licence conditions');
+        }
+        if (profile.asruLicensing) {
+          return model.setStatus(autoResolved.id);
+        }
+        return model.setStatus(withLicensing.id);
       case 'create':
         // new in-progress PIL (user hasn't submitted to NTCO yet), does not need review
         return model.setStatus(autoResolved.id);
 
       case 'revoke':
-        return Promise.resolve()
-          .then(() => Profile.query().findById(changedBy))
-          .then(profile => {
-            if (profile.asruUser) {
-              // PIL revoked by licensing, does not need review
-              return model.setStatus(autoResolved.id);
-            }
-            // PIL revoked by establishment user - needs licensing review.
-            return model.setStatus(withLicensing.id);
-          });
+        if (profile.asruUser) {
+          // PIL revoked by licensing, does not need review
+          return model.setStatus(autoResolved.id);
+        }
+        // PIL revoked by establishment user - needs licensing review.
+        return model.setStatus(withLicensing.id);
       case 'grant':
+        if (profile.asruUser && isAmendment) {
+          return model.setStatus(withLicensing.id);
+        }
         // PIL submitted to NTCO, needs review
         return model.setStatus(awaitingEndorsement.id);
     }


### PR DESCRIPTION
If a PIL amendment has been initiated by an ASRU user then don't send it via the NTCO for endorsement.

Also remove some database lookups that weren't required because the profile data was already present on the hook argument.