### PR TITLE
Don't send an activity log for autoresolved tasks

### DIFF
--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -1,4 +1,5 @@
 const Cacheable = require('./cacheable');
+const { autoResolved } = require('../flow/status');
 
 module.exports = settings => {
 
@@ -8,6 +9,12 @@ module.exports = settings => {
   return c => {
     if (!c.activityLog) {
       return c;
+    }
+    if (c.status === autoResolved.id) {
+      return {
+        ...c,
+        activityLog: null
+      };
     }
 
     const promises = c.activityLog.map(log => cache.query(Profile, log.changedBy));


### PR DESCRIPTION
This should make autoresolved things resolve a little quicker because it doesn't need to do the work to populate the log, and doesn't need to send the payload over the wire.