### PR TITLE
Add secondary query to filtered task lists to get unfiltered total

### DIFF
--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -86,9 +86,13 @@ module.exports = ({ profile, sort = { column: 'updatedAt' }, limit, offset, filt
   }
 
   let query = buildQuery(progress, profile, filters);
-
   query = Case.orderBy({ query, sort });
   query = Case.paginate({ query, limit, offset });
+
+  query.total = () => {
+    return buildQuery(progress, profile).count()
+      .then(result => parseInt(result[0].count, 10));
+  };
 
   return query;
 

--- a/lib/router/tasks.js
+++ b/lib/router/tasks.js
@@ -12,13 +12,15 @@ module.exports = (taskflow) => {
     Promise.resolve()
       .then(() => {
         const profile = req.user.profile;
-        return queryBuilder({ profile, ...req.query });
+        const query = queryBuilder({ profile, ...req.query });
+        return Promise.all([query, query.total()]);
       })
+      .then(([ result, totalCount ]) => ({ ...result, totalCount }))
       .then(cases => {
         const end = process.hrtime(start);
         req.log('info', `task-list query took ${(end[0] * 1000) + Math.round(end[1] / 1e6)}ms`);
         const send = taskflow.responder(req, res);
-        return send(cases.results, { count: cases.total });
+        return send(cases.results, { count: cases.total, total: cases.totalCount });
       })
       .catch(next);
   });


### PR DESCRIPTION
Returns the number of tasks before filters have been applied in order to return the unfiltered total to the user.