### PR TITLE
Ensure user is ASRU user before autoresolving

### DIFF
--- a/lib/hooks/create/pil.js
+++ b/lib/hooks/create/pil.js
@@ -28,7 +28,7 @@ module.exports = settings => {
         // PIL revoked by establishment user - needs licensing review.
         return model.setStatus(withLicensing.id);
       case 'grant':
-        if (profile.asruLicensing) {
+        if (profile.asruUser && profile.asruLicensing) {
           return model.setStatus(autoResolved.id);
         }
         if (profile.asruUser) {


### PR DESCRIPTION
Otherwise user's who have previously been licensing officers, but no longer ASRU can autoresolve PILs.