### PR TITLE
Check we have a profile before checking properties

### DIFF
--- a/lib/middleware/profile.js
+++ b/lib/middleware/profile.js
@@ -9,7 +9,7 @@ module.exports = settings => {
       .findOne({ userId: req.user.id })
       .eager('[roles, establishments, asru]')
       .then(profile => {
-        if (!profile.asruUser) {
+        if (profile && !profile.asruUser) {
           profile.asruLicensing = false;
           profile.asruInspector = false;
           profile.asruAdmin = false;


### PR DESCRIPTION
User's without an existing profile (e.g. new invites, test users with no seeds) were throwing an error because `profile` is undefined.