### PR TITLE
Remove edit and resubmit as next step option for admins on pil transfer

### DIFF
--- a/lib/flow/get-next-steps-for-user.js
+++ b/lib/flow/get-next-steps-for-user.js
@@ -2,6 +2,7 @@ const { get } = require('lodash');
 const flow = require('../flow');
 const { recalledByApplicant, discardedByApplicant } = require('../flow/status');
 const queryBuilder = require('../query-builders');
+const { updated } = require('./status');
 
 const userCreatedThisTask = (c, profile) => {
   if (!c.data.changedBy) {
@@ -32,6 +33,9 @@ module.exports = (c, profile) => {
     .then(cases => cases.results.length > 0)
     .then(canActionTask => {
       if (canActionTask) {
+        if (c.data.model === 'pil' && c.data.action === 'transfer' && !userCreatedThisTask(c, profile)) {
+          return flow.getNextSteps(c).filter(step => step.id !== updated.id); // prevent edit and resubmit by receiving admin
+        }
         return flow.getNextSteps(c);
       }
 

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -4,7 +4,8 @@ module.exports = {
   pil: {
     grant: uuid(),
     applied: uuid(),
-    rejected: uuid()
+    rejected: uuid(),
+    transfer: uuid()
   },
   place: {
     applied: uuid(),

--- a/test/data/profiles.js
+++ b/test/data/profiles.js
@@ -24,6 +24,11 @@ module.exports = {
     establishments: [ { id: 100, role: 'admin' }, { id: 102, role: 'admin' } ],
     roles: []
   },
+  holc101: {
+    id: '143e500a-d42d-4010-840e-35418660cdc2',
+    establishments: [ { id: 101, role: 'admin' } ],
+    roles: []
+  },
   ntco: {
     id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d0',
     establishments: [ { id: 100 } ],

--- a/test/data/tasks.js
+++ b/test/data/tasks.js
@@ -1,5 +1,5 @@
 const uuid = require('uuid/v4');
-const { user, holc, inspector } = require('./profiles');
+const { user, userAtMultipleEstablishments, holc, inspector } = require('./profiles');
 const ids = require('./ids');
 const moment = require('moment');
 
@@ -54,6 +54,21 @@ module.exports = query => query.insert([
       model: 'pil',
       action: 'grant',
       changedBy: holc.id
+    },
+    status: 'returned-to-applicant',
+    ...generateDates(2)
+  },
+  {
+    id: ids.pil.transfer,
+    data: {
+      data: {
+        name: 'pil transfer recalled'
+      },
+      establishmentId: 101,
+      subject: userAtMultipleEstablishments.id,
+      model: 'pil',
+      action: 'transfer',
+      changedBy: userAtMultipleEstablishments.id
     },
     status: 'returned-to-applicant',
     ...generateDates(2)

--- a/test/integration/task-lists/inspector.js
+++ b/test/integration/task-lists/inspector.js
@@ -87,6 +87,7 @@ describe('Inspector', () => {
       const expected = [
         'pil returned',
         'pil with licensing',
+        'pil transfer recalled',
         'place update with licensing',
         'place update with licensing - other establishment',
         'place update recommended',

--- a/test/integration/task-lists/licensing.js
+++ b/test/integration/task-lists/licensing.js
@@ -104,6 +104,7 @@ describe('Licensing Officer', () => {
     it('sees tasks that are with inspectors or returned to establishments', () => {
       const expected = [
         'pil returned',
+        'pil transfer recalled',
         'place update with inspector',
         'conditions update',
         'Submitted by HOLC',


### PR DESCRIPTION
The receiving admin on a PIL transfer cannot edit the request as the PIL is still owned by the original establishment until the task is approved. Remove the option to edit unless it's the applicant viewing the task.