### PR TITLE
Suppress "resubmitted" option in project next steps

### DIFF
--- a/lib/decorators/next-steps.js
+++ b/lib/decorators/next-steps.js
@@ -1,4 +1,5 @@
 const getNextStepsForUser = require('../flow/get-next-steps-for-user');
+const { resubmitted } = require('../flow/status');
 
 module.exports = settings => {
 
@@ -10,6 +11,9 @@ module.exports = settings => {
 
     return getNextStepsForUser(c, user.profile)
       .then(nextSteps => {
+        if (c.data.model === 'project' && c.data.action === 'grant') {
+          nextSteps = nextSteps.filter(s => s.id !== resubmitted.id);
+        }
         return {
           ...c,
           nextSteps

--- a/lib/hooks/validate/status.js
+++ b/lib/hooks/validate/status.js
@@ -13,7 +13,7 @@ module.exports = () => {
           .then(steps => steps.map(step => step.id))
           .then(validNextSteps => {
             if (!validNextSteps.includes(nextStatus)) {
-              throw new BadRequestError('Invalid status change');
+              throw new BadRequestError(`Invalid status change: ${model.status}:${nextStatus}`);
             }
           })
           .then(() => {

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -2,11 +2,15 @@ const uuid = require('uuid/v4');
 
 module.exports = {
   pil: {
+    grant: uuid(),
     applied: uuid(),
     rejected: uuid()
   },
   place: {
     applied: uuid(),
     resolved: uuid()
+  },
+  project: {
+    grant: uuid()
   }
 };

--- a/test/data/tasks.js
+++ b/test/data/tasks.js
@@ -44,7 +44,7 @@ module.exports = query => query.insert([
     ...generateDates(1)
   },
   {
-    id: uuid(),
+    id: ids.pil.grant,
     data: {
       data: {
         name: 'pil returned'
@@ -74,10 +74,14 @@ module.exports = query => query.insert([
     ...generateDates(3)
   },
   {
-    id: uuid(),
+    id: ids.project.grant,
     data: {
       data: {
-        name: 'recalled ppl'
+        name: 'recalled ppl',
+        version: uuid()
+      },
+      meta: {
+        authority: 'yes'
       },
       establishmentId: 100,
       subject: user.id,

--- a/test/integration/tasks/applicant.js
+++ b/test/integration/tasks/applicant.js
@@ -1,3 +1,5 @@
+const assert = require('assert');
+const uuid = require('uuid/v4');
 const request = require('supertest');
 const workflowHelper = require('../../helpers/workflow');
 const { user } = require('../../data/profiles');
@@ -6,6 +8,7 @@ const {
   resubmitted,
   resolved,
   withNtco,
+  withInspectorate,
   discardedByApplicant,
   recalledByApplicant
 } = require('../../../lib/flow/status');
@@ -104,6 +107,24 @@ describe('Applicant', () => {
               }
             })
             .expect(200);
+        });
+    });
+
+    it('can resubmit a recalled ppl application', () => {
+      const version = uuid();
+      return request(this.workflow)
+        .put(`/${ids.project.grant}/status`)
+        .send({
+          status: resubmitted.id,
+          meta: {
+            version,
+            comment: 'resubmitting a pil'
+          }
+        })
+        .expect(200)
+        .expect(response => {
+          assert.equal(response.body.data.status, withInspectorate.id);
+          assert.equal(response.body.data.data.data.version, version);
         });
     });
 

--- a/test/integration/tasks/next-steps.js
+++ b/test/integration/tasks/next-steps.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const request = require('supertest');
+const workflowHelper = require('../../helpers/workflow');
+const { user } = require('../../data/profiles');
+const {
+  resubmitted
+} = require('../../../lib/flow/status');
+
+const ids = require('../../data/ids');
+
+describe('Next steps', () => {
+  before(() => {
+    return workflowHelper.create()
+      .then(workflow => {
+        this.workflow = workflow;
+        this.workflow.setUser({ profile: user });
+      });
+  });
+
+  beforeEach(() => {
+    return Promise.resolve()
+      .then(() => workflowHelper.resetDBs())
+      .then(() => workflowHelper.seedTaskList());
+  });
+
+  after(() => {
+    return workflowHelper.destroy();
+  });
+
+  it('resubmitted appears as an option on a pil.grant task', () => {
+    return request(this.workflow)
+      .get(`/${ids.pil.grant}`)
+      .expect(200)
+      .expect(response => {
+        assert.ok(response.body.data.nextSteps.find(s => s.id === resubmitted.id), 'Next steps should include resubmitted');
+      });
+  });
+
+  it('resubmitted does not appear as an option on a project.grant task', () => {
+    return request(this.workflow)
+      .get(`/${ids.project.grant}`)
+      .expect(200)
+      .expect(response => {
+        assert.ok(!response.body.data.nextSteps.find(s => s.id === resubmitted.id), 'Next steps should not include resubmitted');
+      });
+  });
+
+});


### PR DESCRIPTION
If a project grant or update task is back with a user then force them down the journey of "edit and resubmit" rather than allowing direct resubmission.

The actual available next steps need to be as they are because when it eventually submits it submits with a status of "resubmitted" and so the validator needs to allow that.