### PR TITLE
Send error statuses in error logs

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -90,7 +90,7 @@ module.exports = settings => {
 
   app.use((err, req, res, json) => {
     err.status = err.status || 500;
-    req.log('error', { ...err, message: err.message, stack: err.stack });
+    req.log('error', { ...err, message: err.message, stack: err.stack, status: err.status });
     res.status(err.status);
     res.json({
       message: err.message,


### PR DESCRIPTION
So we can filter 404s from legit errors.