### PR TITLE
Detect errors from resolver written back to changelog

### DIFF
--- a/lib/messager/index.js
+++ b/lib/messager/index.js
@@ -20,6 +20,9 @@ module.exports = settings => {
         .then(() => Changelog.query().findById(id))
         .then(model => {
           if (model) {
+            if (model.action === 'error') {
+              return reject(new Error(model.state.message || 'Resolver failed'));
+            }
             return resolve(model);
           } else if (Number(new Date()) < endTime) {
             setTimeout(checkCondition, POLL_INTERVAL, resolve, reject);


### PR DESCRIPTION
If a changelog record for a message is detected then read the content of the record and throw an error accordingly.

This allows any errors in the resolution of messages to be exposed back to the user immediately without needing to wait for a timeout.