### PR TITLE
Add the task type to the api response

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -49,6 +49,7 @@ module.exports = settings => {
   const flow = Taskflow({ db: settings.taskflowDB });
 
   flow.decorate(decorators.metadata(settings));
+  flow.decorate(decorators.taskType);
   flow.decorate(decorators.deadline(settings));
   flow.decorate(decorators.filterComments(settings), { list: false });
   flow.decorate(decorators.deleteComments(settings), { list: false });

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -5,5 +5,6 @@ module.exports = {
   licenceHolder: require('./licence-holder'),
   deadline: require('./deadline'),
   filterComments: require('./filter-comments'),
-  deleteComments: require('./delete-comments')
+  deleteComments: require('./delete-comments'),
+  taskType: require('./task-type')
 };

--- a/lib/decorators/metadata.js
+++ b/lib/decorators/metadata.js
@@ -14,7 +14,7 @@ const getTaskType = task => {
     return 'revocation';
   }
 
-  if (action === 'grant' && modelStatus === 'inactive') {
+  if (action === 'grant' && modelStatus !== 'active') {
     return 'application';
   }
 

--- a/lib/decorators/metadata.js
+++ b/lib/decorators/metadata.js
@@ -4,7 +4,6 @@ const { closed, withASRU, editable } = require('../flow');
 
 const getTaskType = task => {
   const action = get(task, 'data.action');
-  const model = get(task, 'data.model');
   const modelStatus = get(task, 'data.modelData.status');
 
   if (action === 'transfer') {
@@ -15,18 +14,11 @@ const getTaskType = task => {
     return 'revocation';
   }
 
-  if (action === 'update') {
-    if (model === 'project') {
-      return 'update-licence-holder';
-    }
-    return 'amendment';
+  if (action === 'grant' && modelStatus === 'inactive') {
+    return 'application';
   }
 
-  if (modelStatus === 'active') {
-    return 'amendment';
-  }
-
-  return 'application';
+  return 'amendment';
 };
 
 module.exports = settings => {

--- a/lib/decorators/metadata.js
+++ b/lib/decorators/metadata.js
@@ -1,25 +1,5 @@
-const { get } = require('lodash');
 const Cacheable = require('./cacheable');
 const { closed, withASRU, editable } = require('../flow');
-
-const getTaskType = task => {
-  const action = get(task, 'data.action');
-  const modelStatus = get(task, 'data.modelData.status');
-
-  if (action === 'transfer') {
-    return 'transfer';
-  }
-
-  if (action === 'revoke') {
-    return 'revocation';
-  }
-
-  if (action === 'grant' && modelStatus !== 'active') {
-    return 'application';
-  }
-
-  return 'amendment';
-};
 
 module.exports = settings => {
 
@@ -40,7 +20,6 @@ module.exports = settings => {
     const isOpen = !closedStatuses.includes(c.status);
     const withASRU = withASRUStatuses.includes(c.status);
     const editable = editableStatuses.includes(c.status);
-    const type = getTaskType(c);
 
     return Promise.all(promises)
       .then(([establishment, subject, changedBy]) => {
@@ -55,8 +34,7 @@ module.exports = settings => {
           },
           isOpen,
           withASRU,
-          editable,
-          type
+          editable
         };
       });
 

--- a/lib/decorators/metadata.js
+++ b/lib/decorators/metadata.js
@@ -1,5 +1,33 @@
+const { get } = require('lodash');
 const Cacheable = require('./cacheable');
 const { closed, withASRU, editable } = require('../flow');
+
+const getTaskType = task => {
+  const action = get(task, 'data.action');
+  const model = get(task, 'data.model');
+  const modelStatus = get(task, 'data.modelData.status');
+
+  if (action === 'transfer') {
+    return 'transfer';
+  }
+
+  if (action === 'revoke') {
+    return 'revocation';
+  }
+
+  if (action === 'update') {
+    if (model === 'project') {
+      return 'update-licence-holder';
+    }
+    return 'amendment';
+  }
+
+  if (modelStatus === 'active') {
+    return 'amendment';
+  }
+
+  return 'application';
+};
 
 module.exports = settings => {
 
@@ -20,6 +48,7 @@ module.exports = settings => {
     const isOpen = !closedStatuses.includes(c.status);
     const withASRU = withASRUStatuses.includes(c.status);
     const editable = editableStatuses.includes(c.status);
+    const type = getTaskType(c);
 
     return Promise.all(promises)
       .then(([establishment, subject, changedBy]) => {
@@ -34,7 +63,8 @@ module.exports = settings => {
           },
           isOpen,
           withASRU,
-          editable
+          editable,
+          type
         };
       });
 

--- a/lib/decorators/task-type.js
+++ b/lib/decorators/task-type.js
@@ -1,0 +1,27 @@
+const { get } = require('lodash');
+
+const getTaskType = task => {
+  const action = get(task, 'data.action');
+  const modelStatus = get(task, 'data.modelData.status', 'inactive');
+
+  if (action === 'transfer') {
+    return 'transfer';
+  }
+
+  if (action === 'revoke') {
+    return 'revocation';
+  }
+
+  if (action === 'grant' && modelStatus !== 'active') {
+    return 'application';
+  }
+
+  return 'amendment';
+};
+
+module.exports = c => (
+  {
+    ...c,
+    type: getTaskType(c)
+  }
+);

--- a/test/unit/decorators/task-type.js
+++ b/test/unit/decorators/task-type.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const decorator = require('../../../lib/decorators/task-type');
+
+describe('Task type', () => {
+
+  it('if the action is transfer, then the type is transfer', () => {
+    const task = {
+      data: {
+        action: 'transfer'
+      }
+    };
+    assert.ok(decorator(task).type === 'transfer');
+  });
+
+  it('if the action is revoke, then the type is revocation', () => {
+    const task = {
+      data: {
+        action: 'revoke'
+      }
+    };
+    assert.ok(decorator(task).type === 'revocation');
+  });
+
+  it('if action is grant, and the existing model status is not active, then the type is application', () => {
+    const task = {
+      data: {
+        action: 'grant',
+        model: 'pil',
+        modelData: {
+          status: 'inactive'
+        }
+      }
+    };
+    assert.ok(decorator(task).type === 'application');
+  });
+
+  it('otherwise defaults to amendment', () => {
+    const task = {
+      data: {
+        action: 'grant',
+        model: 'pil',
+        modelData: {
+          status: 'active'
+        }
+      }
+    };
+    assert.ok(decorator(task).type === 'amendment');
+
+    const task2 = {
+      data: {
+        action: 'update',
+        model: 'establishment',
+        modelData: {
+          status: 'active'
+        }
+      }
+    };
+
+    assert.ok(decorator(task2).type === 'amendment');
+  });
+
+});


### PR DESCRIPTION
Add task type (application / amendment / transfer / revocation) to the returned task metadata.

This is to replace several repetitions of the same code in the UI:

https://github.com/UKHomeOffice/asl-pages/blob/master/pages/task/read/routers/read.js#L157-L180

https://github.com/UKHomeOffice/asl-pages/blob/master/pages/common/routers/success.js#L39-L47

https://github.com/UKHomeOffice/asl-pages/blob/master/pages/project/read/views/index.jsx#L82-L100

