### PR TITLE
Show establishment tasks in "My Tasks" tab

### DIFF
--- a/lib/hooks/meta/default.js
+++ b/lib/hooks/meta/default.js
@@ -4,7 +4,10 @@ module.exports = (settings, model) => {
   const data = get(model, 'data', {});
 
   const subject = data.subject || get(data, 'data.profileId') || get(data, 'data.licenceHolderId');
-  const establishmentId = data.establishmentId || get(data, 'data.establishmentId');
+
+  const establishmentId = data.establishmentId ||
+    get(data, 'data.establishmentId') ||
+    get(data, 'model') === 'establishment' ? get(data, 'id') : undefined;
 
   return model.patch({ subject, establishmentId });
 };

--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -69,8 +69,6 @@ const buildQuery = (progress, profile, filters) => {
     }
   });
 
-  console.log(query.toString());
-
   return query;
 };
 

--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -69,6 +69,8 @@ const buildQuery = (progress, profile, filters) => {
     }
   });
 
+  console.log(query.toString());
+
   return query;
 };
 

--- a/lib/query-builders/inspector.js
+++ b/lib/query-builders/inspector.js
@@ -18,6 +18,7 @@ module.exports = {
       profile.asru
         .forEach(establishment => {
           builder.orWhereJsonSupersetOf('data', { establishmentId: establishment.id });
+          builder.orWhereJsonSupersetOf('data', { id: establishment.id, model: 'establishment' });
         });
     })
       .whereIn('status', [

--- a/lib/query-builders/licensing-officer.js
+++ b/lib/query-builders/licensing-officer.js
@@ -18,6 +18,7 @@ module.exports = {
       profile.asru
         .forEach(establishment => {
           builder.orWhereJsonSupersetOf('data', { establishmentId: establishment.id });
+          builder.orWhereJsonSupersetOf('data', { id: establishment.id, model: 'establishment' });
         });
     })
       .whereIn('status', [


### PR DESCRIPTION
Establishment tasks don't send an `establishmentId` param on creation (just `id`) so it was not being copied to the task in the expected place for the queryBuilder to query on it.