### PR TITLE
Whitelist progress states in task list builder

### DIFF
--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -16,6 +16,13 @@ const licensing = require('./licensing-officer');
 const inspector = require('./inspector');
 const asru = require('./asru');
 
+const progressStates = [
+  'myTasks',
+  'outstanding',
+  'inProgress',
+  'completed'
+];
+
 const buildQuery = (progress, profile, filters) => {
   const userIsNtco = userHasNamedRole('ntco', profile);
   const userIsAdmin = userHasPermission('admin', profile);
@@ -74,11 +81,12 @@ const buildQuery = (progress, profile, filters) => {
 
 module.exports = ({ profile, sort = { column: 'updatedAt' }, limit, offset, filters, progress = 'outstanding' }) => {
 
-  if (!profile) {
-    return Promise.resolve({
+  if (!profile || !progressStates.includes(progress)) {
+    return {
       results: [],
-      count: 0
-    });
+      count: 0,
+      total: () => Promise.resolve(0)
+    };
   }
 
   if (isUndefined(sort.ascending) && sort.column === 'updatedAt') {

--- a/test/integration/task-lists/error-states.js
+++ b/test/integration/task-lists/error-states.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const assert = require('assert');
+
+const workflowHelper = require('../../helpers/workflow');
+
+const { user } = require('../../data/profiles');
+
+describe('Task list error states', () => {
+  before(() => {
+    return workflowHelper.create()
+      .then(workflow => {
+        this.workflow = workflow;
+      });
+  });
+
+  beforeEach(() => {
+    return Promise.resolve()
+      .then(() => workflowHelper.resetDBs())
+      .then(() => workflowHelper.seedTaskList());
+  });
+
+  after(() => {
+    return workflowHelper.destroy();
+  });
+
+  it('returns an empty list if no profile is found', () => {
+    this.workflow.setUser({ profile: null });
+    return request(this.workflow)
+      .get('/')
+      .expect(200)
+      .expect(response => {
+        assert.deepEqual(response.body.data, []);
+      });
+  });
+
+  it('returns an empty list if non-existent progress state is provided', () => {
+    this.workflow.setUser({ profile: user });
+    return request(this.workflow)
+      .get('/?progress=junk')
+      .expect(200)
+      .expect(response => {
+        assert.deepEqual(response.body.data, []);
+      });
+  });
+});


### PR DESCRIPTION
If you request a task list with a broken progress parameter in the query string then it returns the default underlying query which returns _everything_ with no status filters (including autoresolved) which then breaks in the client.

Instead return an empty list immediately if the progress parameter doesn't make an expected value.