### PR TITLE
Expand profile tasks endpoint

### DIFF
--- a/lib/router/profile-tasks.js
+++ b/lib/router/profile-tasks.js
@@ -10,20 +10,33 @@ module.exports = (taskflow) => {
 
   router.get('/:profileId', (req, res, next) => {
     const { profileId } = req.params;
-    const { establishmentId } = req.query;
+    const { establishmentId, all, sort, limit, offset } = req.query;
     const send = taskflow.responder(req, res);
-    Promise.resolve()
-      .then(() => {
-        return Case.query()
+    let query = Case.query()
+      .where(builder => {
+        builder
           .whereJsonSupersetOf('data', { subject: profileId })
-          .where(builder => {
-            if (establishmentId) {
-              filterToEstablishments([parseInt(establishmentId, 10)])(builder);
-            }
-          })
-          .whereIn('status', open());
+          .orWhereJsonSupersetOf('data', { changedBy: profileId });
       })
-      .then(send)
+      .where(builder => {
+        if (establishmentId) {
+          filterToEstablishments([parseInt(establishmentId, 10)])(builder);
+        }
+      })
+      .where(builder => {
+        if (all !== 'true') {
+          builder.whereIn('status', open());
+        }
+      });
+
+    query = Case.orderBy({ query, sort });
+    query = Case.paginate({ query, limit, offset });
+
+    Promise.resolve()
+      .then(() => query)
+      .then((results) => {
+        send(results.results, { count: results.total });
+      })
       .catch(next);
   });
 

--- a/test/integration/profile-tasks/index.js
+++ b/test/integration/profile-tasks/index.js
@@ -24,13 +24,14 @@ describe('Subject', () => {
     return workflowHelper.destroy();
   });
 
-  it('returns open tasks for the subject', () => {
+  it('returns open tasks where user is the subject or opened the task', () => {
     const expected = [
       'recalled ppl',
       'pil returned',
       'pil with ntco',
       'pil with licensing',
       'another with-ntco to test ordering',
+      'another with-inspectorate to test ordering',
       'project awaiting endorsement'
     ];
     return request(this.workflow)


### PR DESCRIPTION
Adds pagination to the endpoint and allows non-open tasks to be included in the results if a query string parameter is passed.

Also includes tasks opened by the user as well as about the user in the response. This is acceptable in terms of the impact on its other use in preventing profile mergers as we probably shouldn't allow mergers if there are open tasks created by a user anyway because it will mess with "return to applicant" functionality.