### PR TITLE
Bugfix - dont mutate next steps from settings

### DIFF
--- a/lib/flow/index.js
+++ b/lib/flow/index.js
@@ -56,7 +56,9 @@ flow[referredToInspector.id] = [inspectorRecommended, inspectorRejected, returne
 
 const getNextSteps = c => {
   const action = get(c, 'data.action');
-  const nextSteps = get(flow, c.status, []);
+  const nextSteps = [
+    ...get(flow, c.status, [])
+  ];
   // delete and revoke tasks do not include any
   // data apart from supporting comments
   if (['delete', 'revoke'].includes(action)) {


### PR DESCRIPTION
* flow.getNextSteps is returning a reference to the array from settings - we should clone this before mutating to avoid a memory leak