### PR TITLE
Only try to set ASRU flag on task if profile exists

### DIFF
--- a/lib/hooks/meta/index.js
+++ b/lib/hooks/meta/index.js
@@ -16,8 +16,10 @@ module.exports = settings => {
     const changedBy = data.changedBy;
     const nopes = ['asruEstablishment', 'feeWaiver'];
 
-    const profile = await Profile.query().findById(changedBy);
-    await model.patch({ initiatedByAsru: !!profile.asruUser });
+    if (changedBy) {
+      const profile = await Profile.query().findById(changedBy);
+      await model.patch({ initiatedByAsru: !!profile.asruUser });
+    }
 
     if (nopes.includes(type)) {
       return Promise.resolve();

--- a/test/integration/profile/update.js
+++ b/test/integration/profile/update.js
@@ -23,6 +23,28 @@ describe('Profile update', () => {
     return workflowHelper.destroy();
   });
 
+  describe('create profile', () => {
+    it('autoresolves profile creation tasks', () => {
+      return request(this.workflow)
+        .post('/')
+        .send({
+          model: 'profile',
+          id: user.id,
+          action: 'create',
+          data: {
+            firstName: 'Linford',
+            lastName: 'Christie',
+            email: 'test@example.com'
+          }
+        })
+        .expect(200)
+        .then(response => response.body.data)
+        .then(task => {
+          assert.equal(task.status, autoResolved.id);
+        });
+    });
+  });
+
   describe('User with no licences or named roles', () => {
 
     it('auto-resolves changes that don\'t include the name or DOB', () => {


### PR DESCRIPTION
Profile creation tasks don't have a `changedBy` (by definition) and so the database lookup based on that parameter fails.