### PR TITLE
Allow conditions updates to establishments when there is an open task

### DIFF
--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -1,4 +1,5 @@
 const { get } = require('lodash');
+const match = require('minimatch');
 const { BadRequestError } = require('@asl/service/errors');
 
 const Case = require('@ukhomeoffice/taskflow/lib/models/case');
@@ -11,16 +12,15 @@ module.exports = settings => {
     const type = get(model, 'meta.data.model');
     const action = get(model, 'meta.data.action');
 
-    // skip if forking a project
-    if (type === 'project' && action === 'fork') {
-      return;
-    }
+    // allow tasks of the following types to be raised even if other open tasks exist
+    const nopes = [
+      'feeWaiver.*',
+      'project.fork',
+      'establishment.update-conditions',
+      'establishment.update-billing'
+    ];
 
-    if (type === 'feeWaiver') {
-      return;
-    }
-
-    if (action === 'update-billing') {
+    if (nopes.some(str => match(`${type}.${action}`, str))) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.16.4",
     "knex": "^0.20.1",
     "lodash": "^4.17.15",
+    "minimatch": "^3.0.4",
     "moment": "^2.24.0",
     "moment-business-time": "^0.7.1",
     "r2": "^2.0.1",

--- a/test/integration/establishment/conditions.js
+++ b/test/integration/establishment/conditions.js
@@ -1,0 +1,52 @@
+const request = require('supertest');
+const workflowHelper = require('../../helpers/workflow');
+const profiles = require('../../data/profiles');
+
+describe('Update conditions', () => {
+  before(() => {
+    return workflowHelper.create()
+      .then(workflow => {
+        this.workflow = workflow;
+      });
+  });
+
+  beforeEach(() => {
+    return Promise.resolve()
+      .then(() => workflowHelper.resetDBs())
+      .then(() => workflowHelper.seedTaskList());
+  });
+
+  after(() => {
+    return workflowHelper.destroy();
+  });
+
+  it('can be created even if an open task for the establishment exists', () => {
+    return Promise.resolve()
+      .then(() => {
+        return request(this.workflow)
+          .post('/')
+          .send({
+            model: 'establishment',
+            action: 'update',
+            id: 101,
+            data: {
+              address: '123 nowhere street'
+            },
+            changedBy: profiles.holc101.id
+          })
+          .expect(200);
+      })
+      .then(() => {
+        return request(this.workflow)
+          .post('/')
+          .send({
+            model: 'establishment',
+            action: 'update-conditions',
+            id: 101,
+            changedBy: profiles.licensing.id
+          })
+          .expect(200);
+      });
+  });
+
+});


### PR DESCRIPTION
PEL condition updates autoresolve, and can't conflict with an open task so can safely be disregarded when checking for conflicting tasks.