### PR TITLE
Separate PIL grant tasks into applications and amendments

### DIFF
--- a/lib/router/metrics.js
+++ b/lib/router/metrics.js
@@ -29,9 +29,9 @@ module.exports = (taskflow, settings) => {
         return cases.map(c => {
           let type = `${c.data.model}-${c.data.action}`;
           let schemaVersion;
-          if (c.data.model === 'project' && c.data.action === 'grant') {
-            const isAmendment = get(c, 'data.modelData.status') !== 'inactive';
-            type = `project-${isAmendment ? 'amendment' : 'application'}`;
+          if (['pil', 'project'].includes(c.data.model) && c.data.action === 'grant') {
+            const isAmendment = get(c, 'data.modelData.status') === 'active';
+            type = `${c.data.model}-${isAmendment ? 'amendment' : 'application'}`;
           }
           if (c.data.model === 'project') {
             schemaVersion = get(c, 'data.modelData.schemaVersion');


### PR DESCRIPTION
Currently all PIL amendments and applications are grant tasks, so appear as applications in the performance dashboard.

Split them into applications and amendments by checking the current status.