### PR TITLE
Add test to ensure deadline calculation is not sensitive to activity log ordering

### DIFF
--- a/test/unit/decorators/deadline.js
+++ b/test/unit/decorators/deadline.js
@@ -214,6 +214,47 @@ describe('Deadline', () => {
     });
   });
 
+  it('sets a deadline based on the most recent submission and is not sensitive to ordering of activity log records', () => {
+    const task = {
+      status: 'with-inspectorate',
+      createdAt: '2019-09-20T10:00:00.000Z',
+      data: {
+        model: 'project',
+        action: 'grant',
+        modelData: {
+          status: 'inactive'
+        },
+        meta: {
+          authority: 'yes',
+          awerb: 'yes',
+          ready: 'yes'
+        }
+      },
+      activityLog: [
+        {
+          eventName: 'status:returned-to-applicant:with-inspectorate',
+          createdAt: '2019-09-24T10:00:00.100Z'
+        },
+        {
+          eventName: 'status:with-inspectorate:returned-to-applicant',
+          createdAt: '2019-09-21T10:00:00.100Z'
+        },
+        {
+          eventName: 'status:new:with-inspectorate',
+          createdAt: '2019-09-20T10:00:00.100Z'
+        },
+        {
+          eventName: 'create',
+          createdAt: '2019-09-20T10:00:00.000Z'
+        }
+      ]
+    };
+    return decorator()(task).then(result => {
+      assert.ok(result.deadline);
+      assert.equal(result.deadline.format('YYYY-MM-DD'), '2019-11-19');
+    });
+  });
+
   it('sets an extended deadline if the task deadline has been extended', () => {
     const task = {
       status: 'with-inspectorate',


### PR DESCRIPTION
The old code was dependent of activity log records being ordered newest to oldest. The new code doesn't care and will return the right value whatever.

Add a test to ensure this continues to be the case.