### PR TITLE
Fix deadline calculation

### DIFF
--- a/lib/decorators/deadline/index.js
+++ b/lib/decorators/deadline/index.js
@@ -34,7 +34,7 @@ module.exports = settings => {
         return c;
       })
       .then(model => {
-        const deadline = getDeadline(c);
+        const deadline = getDeadline(model);
         const isExtendable = c.isOpen && !c.data.extended;
 
         return {


### PR DESCRIPTION
If a task has no activity log attached then we load it to do the deadline calculation, but then weren't actually using the copy of the data which had activity to do the calculation, so it threw errors.