### PR TITLE
Fix status for project submission

### DIFF
--- a/lib/router/metrics/project-sla.js
+++ b/lib/router/metrics/project-sla.js
@@ -1,6 +1,7 @@
 const { ref } = require('objection');
 const moment = require('moment-business-time');
 const { withASRU, closed } = require('../../flow');
+const { withInspectorate } = require('../../flow/status');
 const completeAndCorrect = require('../../decorators/deadline/complete-and-correct');
 
 module.exports = (Case, settings) => {
@@ -14,7 +15,7 @@ module.exports = (Case, settings) => {
       const status = activity.status;
       state.extended = state.extended || activity.extended;
       // if it's a submission to the inspector then make note of the date and mark task as with ASRU
-      if (!state.withASRU && status === 'with-inspector' && completeAndCorrect(activity.meta)) {
+      if (!state.withASRU && status === withInspectorate.id && completeAndCorrect(activity.meta)) {
         return {
           ...state,
           withASRU: true,


### PR DESCRIPTION
Was using an incorrect hard-coded status to calculate project application SLA metrics. Swap this out for the properly defined value.