### PR TITLE
Fix PPL deadline metrics queries

### DIFF
--- a/lib/router/metrics/project-sla.js
+++ b/lib/router/metrics/project-sla.js
@@ -44,21 +44,21 @@ module.exports = (Case, settings) => {
       currentState.hasPassed = hasPassed || currentState.hasPassed;
     }
 
-    return currentState.hasPassed && currentState.deadline.isAfter(since);
+    return currentState.hasPassed && currentState.deadline.isAfter(moment(since, 'YYYY-MM-DD'));
   };
 
   return since => {
     return Promise.resolve()
       .then(() => {
         return Case.query()
-          .eager('[activityLog]')
-          .modifyEager('[activityLog]', builder => {
+          .eager('activityLog')
+          .modifyEager('activityLog', builder => {
             builder
               .select(
                 'createdAt',
                 ref('event:status').castText().as('status'),
-                ref('event:data:extended').castBool().as('extended'),
-                ref('event:data:meta').castJson().as('meta')
+                ref('event:data.extended').castBool().as('extended'),
+                ref('event:data.meta').castJson().as('meta')
               )
               .orderBy('createdAt', 'asc');
           })
@@ -68,8 +68,8 @@ module.exports = (Case, settings) => {
             action: 'grant',
             modelData: { status: 'inactive' }
           })
-          // only things that _might_ have a deadline in the relevant time period
-          .where('created_at', '>', moment(since, 'YYYY-MM-DD').subtract(12, 'weeks').format('YYYY-MM-DD'));
+          // any task created in the last 40 days can't have passed a deadline
+          .where('created_at', '<', moment().subtractWorkingTime(40, 'days').format('YYYY-MM-DD'));
       })
       .then(tasks => {
         return tasks.filter(task => hasPassedDeadline(task, since));


### PR DESCRIPTION
The correct separator for JSON sub-selecting is a `.` not a `:` past the top level field name.

Also the date filter was incorrectly filtering tasks.