### PR TITLE
Bugfix - fork version on recall

### DIFF
--- a/lib/hooks/recall/index.js
+++ b/lib/hooks/recall/index.js
@@ -8,7 +8,7 @@ module.exports = settings => {
     const action = get(model, 'data.action');
     const changedBy = get(model, 'meta.user.profile.id');
 
-    if (type === 'project' && action === 'grant') {
+    if (type === 'project' && (action === 'grant' || action === 'transfer')) {
       return messager({ ...model.data, action: 'fork', meta: { changedBy } });
     }
     return Promise.resolve();

--- a/test/unit/hooks/recall/index.js
+++ b/test/unit/hooks/recall/index.js
@@ -1,0 +1,67 @@
+const uuid = require('uuid/v4');
+const assert = require('assert');
+const sinon = require('sinon');
+const hook = require('../../../../lib/hooks/recall');
+
+const messagerStub = sinon.stub();
+const changedBy = uuid();
+
+const runHook = hook({ StubMessager: messagerStub });
+
+describe.only('Recall hook', () => {
+  beforeEach(() => {
+    messagerStub.reset();
+    this.model = {
+      data: {
+        model: 'project',
+        action: 'grant',
+        data: {
+          some: 'data'
+        }
+      },
+      meta: {
+        user: {
+          profile: {
+            id: changedBy
+          }
+        }
+      }
+    };
+  });
+
+  it('sends a fork action to resolver on project grant', () => {
+    const expected = {
+      ...this.model.data,
+      action: 'fork',
+      meta: { changedBy }
+    };
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.deepEqual(messagerStub.lastCall.args[0], expected);
+      });
+  });
+
+  it('sends a fork action to resolver on project transfer', () => {
+    this.model.data.action = 'transfer';
+    const expected = {
+      ...this.model.data,
+      action: 'fork',
+      meta: { changedBy }
+    };
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.deepEqual(messagerStub.lastCall.args[0], expected);
+      });
+  });
+
+  it('doesn\'t call messager if model is not project', () => {
+    this.model.data.model = 'pil';
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.equal(messagerStub.called, false);
+      });
+  });
+});


### PR DESCRIPTION
We were only forking recalled/returned versions on grant tasks - updated to include transfer