### PR TITLE
Bugfix - dont update id post resolve

### DIFF
--- a/lib/hooks/resolve/index.js
+++ b/lib/hooks/resolve/index.js
@@ -1,18 +1,33 @@
+const { get } = require('lodash');
 const Messager = require('../../messager');
 
 module.exports = settings => {
-
   const messager = Messager(settings);
 
   return model => {
     if (settings.noDownstream) {
       return Promise.resolve();
     }
+
+    const type = get(model, 'data.model');
+    const action = get(model, 'data.action');
+
     return messager(model.data)
       .then(changelogModel => {
         const id = changelogModel.modelId;
-        const result = model.patch({ id });
-        return result || { id };
+
+        if (type === 'project' && action === 'fork') {
+          const data = get(model, 'data.data');
+          data.versionId = id;
+          return model.patch({ data });
+        }
+
+        if (!model.data.id) {
+          const result = model.patch({ id });
+          return result || { id };
+        }
+
+        return model;
       });
   };
 

--- a/test/unit/hooks/resolve/index.js
+++ b/test/unit/hooks/resolve/index.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const uuid = require('uuid/v4');
+const sinon = require('sinon');
+const hook = require('../../../../lib/hooks/resolve');
+
+const modelId = uuid();
+const createdId = uuid();
+
+const runHook = hook({ StubMessager: () => Promise.resolve({ modelId: createdId }) });
+
+describe('Resolve hook', () => {
+  beforeEach(() => {
+    this.model = {
+      data: {
+        id: modelId,
+        data: {
+          some: 'value'
+        }
+      },
+      patch: sinon.stub()
+    };
+  });
+
+  it('updates the data.versionId if task is a project fork', () => {
+    this.model.data.model = 'project';
+    this.model.data.action = 'fork';
+    const expected = {
+      data: {
+        ...this.model.data.data,
+        versionId: createdId
+      }
+    };
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.deepEqual(this.model.patch.lastCall.args[0], expected);
+      });
+  });
+
+  it('updates the top level id if not already set', () => {
+    this.model.data.model = 'place';
+    this.model.data.action = 'create';
+    delete this.model.data.id;
+    const expected = { id: createdId };
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.deepEqual(this.model.patch.lastCall.args[0], expected);
+      });
+  });
+
+  it('doesn\'t patch the model if id is already set', () => {
+    this.model.data.model = 'place';
+    this.model.data.action = 'update';
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.equal(this.model.patch.called, false);
+      });
+  });
+});


### PR DESCRIPTION
* We were using the task id to inform the ui of the new version when forking, update the data.versionId instead
* Don't update id if there is already an id set