### PR TITLE
Feature - ppl transfer

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -36,7 +36,8 @@ const hooks = {
   editAndResubmit: require('./hooks/edit-and-resubmit'),
   discard: require('./hooks/discard'),
   recall: require('./hooks/recall'),
-  endorsed: require('./hooks/endorsed')
+  endorsed: require('./hooks/endorsed'),
+  updateAction: require('./hooks/update-action')
 };
 
 module.exports = settings => {
@@ -61,7 +62,9 @@ module.exports = settings => {
   flow.hook('pre-create', hooks.unique(settings));
 
   flow.hook('create', hooks.meta(settings));
+  flow.hook('create', hooks.updateAction(settings));
   flow.hook('create', hooks.create(settings));
+  flow.hook(`status:*:${resubmitted.id}`, hooks.updateAction(settings));
   flow.hook(`status:*:${resubmitted.id}`, hooks.create(settings));
 
   flow.hook(`status:*:${recalledByApplicant.id}`, hooks.clearDeadline(settings));

--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -37,7 +37,7 @@ module.exports = settings => {
         if (results && results.length) {
           if (type === 'project' && action === 'grant') {
             const id = results[0].id;
-            return Task.find(id)
+            return model.find(id)
               .then(task => {
                 const status = task.toJSON().status;
                 if (editable().includes(status)) {

--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -4,6 +4,7 @@ const { BadRequestError } = require('@asl/service/errors');
 
 const { Task } = require('@ukhomeoffice/taskflow');
 const { closed } = require('../../flow');
+const { resubmitted } = require('../../flow/status');
 
 module.exports = settings => {
   return model => {
@@ -34,6 +35,12 @@ module.exports = settings => {
       .where('status', '!=', 'new')
       .then(results => {
         if (results && results.length) {
+          if (type === 'project' && action === 'grant') {
+            const id = results[0].id;
+            return Task.find(id)
+              .then(task => task.status(resubmitted.id, model.meta))
+              .then(() => model.redirect(id));
+          }
           throw new BadRequestError('There is an existing open task for this record');
         }
       });

--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -3,7 +3,7 @@ const match = require('minimatch');
 const { BadRequestError } = require('@asl/service/errors');
 
 const { Task } = require('@ukhomeoffice/taskflow');
-const { closed } = require('../../flow');
+const { closed, editable } = require('../../flow');
 const { resubmitted } = require('../../flow/status');
 
 module.exports = settings => {
@@ -38,7 +38,12 @@ module.exports = settings => {
           if (type === 'project' && action === 'grant') {
             const id = results[0].id;
             return Task.find(id)
-              .then(task => task.status(resubmitted.id, model.meta))
+              .then(task => {
+                const status = task.toJSON().status;
+                if (editable().includes(status)) {
+                  return task.status(resubmitted.id, model.meta);
+                }
+              })
               .then(() => model.redirect(id));
           }
           throw new BadRequestError('There is an existing open task for this record');

--- a/lib/hooks/update-action/index.js
+++ b/lib/hooks/update-action/index.js
@@ -1,0 +1,47 @@
+const { get } = require('lodash');
+const { NotFoundError, BadRequestError } = require('@asl/service/errors');
+
+module.exports = settings => {
+
+  const { Project, ProjectVersion, Profile, Establishment } = settings.models;
+
+  return async model => {
+    const type = get(model, 'data.model');
+    const action = get(model, 'data.action');
+    const id = get(model, 'data.id');
+
+    if (type === 'project' && action === 'grant') {
+      const project = await Project.query().findById(id);
+      const version = await ProjectVersion.query().orderBy('createdAt', 'desc').findOne({ projectId: id });
+      const transferToEstablishmentId = get(version, 'data.transferToEstablishment');
+
+      // not a transfer - continue.
+      if (!transferToEstablishmentId) {
+        return Promise.resolve();
+      }
+
+      const transferToEstablishment = await Establishment.query().findById(transferToEstablishmentId);
+
+      if (!transferToEstablishment) {
+        throw new NotFoundError();
+      }
+
+      // not a transfer = continue.
+      if (transferToEstablishment.id === project.establishmentId) {
+        return Promise.resolve();
+      }
+
+      const licenceHolder = await Profile.query().findById(project.licenceHolderId).eager('establishments');
+
+      const licenceHolderEstablishments = licenceHolder.establishments.map(e => e.id);
+
+      if (!licenceHolderEstablishments.includes(transferToEstablishment.id)) {
+        throw new BadRequestError(`User is not associated with ${transferToEstablishment.name}`);
+      }
+
+      return model.patch({ action: 'transfer', data: { establishmentId: transferToEstablishmentId } });
+    }
+
+    return Promise.resolve();
+  };
+};

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -198,9 +198,9 @@ module.exports = models => {
                 version: [
                   {
                     id: uuid(),
-                    status: 'granted',
+                    status: 'draft',
                     data: {
-                      duration: { years: 5, months: 0 }
+                      transferToEstablishment: 101
                     }
                   }
                 ]

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -25,6 +25,7 @@ module.exports = {
       resolved: uuid()
     },
     project: {
+      grant: uuid(),
       transfer: uuid(),
       updateIssueDate: uuid(),
       updateLicenceNumber: uuid()

--- a/test/data/tasks.js
+++ b/test/data/tasks.js
@@ -91,6 +91,7 @@ module.exports = query => query.insert([
   {
     id: ids.task.project.grant,
     data: {
+      id: ids.model.project.grant,
       data: {
         name: 'recalled ppl',
         version: uuid()

--- a/test/helpers/workflow.js
+++ b/test/helpers/workflow.js
@@ -31,10 +31,10 @@ module.exports = {
     return knex.destroy();
   },
 
-  resetDBs: () => {
+  resetDBs: ({ keepalive = false } = {}) => {
     return Promise.resolve()
       .then(() => tfdb.reset())
-      .then(() => aslDb(settings.db).init(fixtures.default));
+      .then(() => aslDb(settings.db).init(fixtures.default, keepalive));
   },
 
   seedTaskList: () => {

--- a/test/integration/project/transfer.js
+++ b/test/integration/project/transfer.js
@@ -32,6 +32,10 @@ describe('Project transfer', () => {
       .then(() => workflowHelper.seedTaskList());
   });
 
+  afterEach(() => {
+    return this.models.destroy();
+  });
+
   after(() => {
     return workflowHelper.destroy();
   });

--- a/test/integration/project/transfer.js
+++ b/test/integration/project/transfer.js
@@ -19,21 +19,77 @@ describe('Project transfer', () => {
     this.workflow.setUser({ profile: userAtMultipleEstablishments });
     payload = {
       model: 'project',
-      action: 'transfer',
+      action: 'grant',
       id: ids.model.project.transfer,
       changedBy: userAtMultipleEstablishments.id,
-      establishmentId: 100,
-      data: {
-        establishmentId: 101
-      }
+      establishmentId: 100
     };
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
+      .then(() => workflowHelper.resetDBs({ keepalive: true }))
+      .then(models => {
+        this.models = models;
+      })
       .then(() => workflowHelper.seedTaskList());
   });
 
   after(() => {
     return workflowHelper.destroy();
+  });
+
+  it('updates the action to `transfer` and adds the transferToEstablishment to data', () => {
+    return request(this.workflow)
+      .post('/')
+      .send(payload)
+      .expect(200)
+      .then(response => {
+        const task = response.body.data;
+        assert.equal(task.data.action, 'transfer');
+        assert.equal(task.data.data.establishmentId, 101);
+      });
+  });
+
+  it('doesn\'t update the action if transferToEstablishment is not included in version', () => {
+    const { ProjectVersion } = this.models;
+    return ProjectVersion.query().findOne({ projectId: ids.model.project.transfer }).patch({ data: { transferToEstablishment: null } })
+      .then(() => request(this.workflow)
+        .post('/')
+        .send(payload)
+        .expect(200)
+        .then(response => {
+          const task = response.body.data;
+          assert.equal(task.data.action, 'grant');
+          assert.equal(task.data.data, undefined);
+        })
+      );
+  });
+
+  it('doesn\'t update the action if transferToEstablishment is the same as current establishment', () => {
+    const { ProjectVersion } = this.models;
+    return ProjectVersion.query().findOne({ projectId: ids.model.project.transfer }).patch({ data: { transferToEstablishment: 100 } })
+      .then(() => request(this.workflow)
+        .post('/')
+        .send(payload)
+        .expect(200)
+        .then(response => {
+          const task = response.body.data;
+          assert.equal(task.data.action, 'grant');
+          assert.equal(task.data.data, undefined);
+        })
+      );
+  });
+
+  it('throws an error if licenceHolder is not associated with transferToEstablishment', () => {
+    const { ProjectVersion } = this.models;
+    return ProjectVersion.query().findOne({ projectId: ids.model.project.transfer }).patch({ data: { transferToEstablishment: 102 } })
+      .then(() => request(this.workflow)
+        .post('/')
+        .send(payload)
+        .expect(400)
+        .then(response => response.body)
+        .then(error => {
+          assert.equal(error.message, 'User is not associated with Research 102');
+        })
+      );
   });
 
   it('updates the establishmentId of the task once endorsed and changes status to awaiting-endorsement', () => {


### PR DESCRIPTION
* Updated unique check to update project grant status to resubmitted if already present, point to existing record rather than creating a new task
* Added update-action hook, this updates the action type of a grant task if it is detected to be a transfer