### PR TITLE
Redirect all matching tasks when resubmitting

### DIFF
--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -12,6 +12,7 @@ module.exports = settings => {
     const id = get(model, 'meta.data.id');
     const type = get(model, 'meta.data.model');
     const action = get(model, 'meta.data.action');
+    const data = get(model, 'meta.data.data');
 
     // allow tasks of the following types to be raised even if other open tasks exist
     const nopes = [
@@ -35,16 +36,19 @@ module.exports = settings => {
       .where('status', '!=', 'new')
       .then(results => {
         if (results && results.length) {
-          if (type === 'project' && action === 'grant') {
-            const id = results[0].id;
-            return model.find(id)
+          const conflict = results[0];
+          const status = conflict.status;
+          // check that the existing task is of the same type and is open
+          if (type === conflict.data.model && action === conflict.data.action && editable().includes(status)) {
+            return model.find(conflict.id)
               .then(task => {
-                const status = task.toJSON().status;
-                if (editable().includes(status)) {
-                  return task.status(resubmitted.id, model.meta);
-                }
+                return Promise.resolve()
+                  // update the existing task with new data
+                  .then(() => task.patch({ data }, model.meta))
+                  // mark existing task as resubmitted
+                  .then(() => task.status(resubmitted.id, model.meta));
               })
-              .then(() => model.redirect(id));
+              .then(() => model.redirect(conflict.id));
           }
           throw new BadRequestError('There is an existing open task for this record');
         }

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -9,7 +9,9 @@ module.exports = {
     },
     place: {
       applied: uuid(),
-      resolved: uuid()
+      resolved: uuid(),
+      returned: uuid(),
+      inspector: uuid()
     },
     project: {
       grant: uuid()
@@ -22,7 +24,8 @@ module.exports = {
     },
     place: {
       applied: uuid(),
-      resolved: uuid()
+      resolved: uuid(),
+      returned: uuid()
     },
     project: {
       grant: uuid(),

--- a/test/data/tasks.js
+++ b/test/data/tasks.js
@@ -181,6 +181,21 @@ module.exports = query => query.insert([
     ...generateDates(9)
   },
   {
+    id: ids.task.place.returned,
+    data: {
+      data: {
+        name: 'place update returned'
+      },
+      establishmentId: 100,
+      model: 'place',
+      action: 'update',
+      id: ids.model.place.returned,
+      changedBy: holc.id
+    },
+    status: 'returned-to-applicant',
+    ...generateDates(9)
+  },
+  {
     id: uuid(),
     data: {
       data: {

--- a/test/helpers/workflow.js
+++ b/test/helpers/workflow.js
@@ -20,7 +20,7 @@ module.exports = {
           ...settings,
           noDownstream: true,
           auth: false,
-          log: { level: 'error' }
+          log: { level: 'silent' }
         }, options));
 
         return WithUser(workflow, {});

--- a/test/integration/task-lists/establishment-admin.js
+++ b/test/integration/task-lists/establishment-admin.js
@@ -31,6 +31,7 @@ describe('Establishment Admin', () => {
     it('sees tasks for their establishment that require action', () => {
       const expected = [
         'pil returned',
+        'place update returned',
         'Submitted by HOLC',
         'recalled ppl',
         'conditions update',

--- a/test/integration/task-lists/inspector.js
+++ b/test/integration/task-lists/inspector.js
@@ -89,6 +89,7 @@ describe('Inspector', () => {
         'pil with licensing',
         'pil transfer recalled',
         'place update with licensing',
+        'place update returned',
         'place update with licensing - other establishment',
         'place update recommended',
         'place update recommend rejected',

--- a/test/integration/task-lists/licensing.js
+++ b/test/integration/task-lists/licensing.js
@@ -106,6 +106,7 @@ describe('Licensing Officer', () => {
         'pil returned',
         'pil transfer recalled',
         'place update with inspector',
+        'place update returned',
         'conditions update',
         'Submitted by HOLC',
         'another with-inspectorate to test ordering',


### PR DESCRIPTION
If a task is created and there is an existing task with a matching model and action, and in an editable state then automatically redirect to that task and update the data with the new payload.