### PR TITLE
Prevent external users actioning ASRU tasks

### DIFF
--- a/lib/flow/get-next-steps-for-user.js
+++ b/lib/flow/get-next-steps-for-user.js
@@ -3,20 +3,20 @@ const flow = require('./index');
 const { updated, recalledByApplicant, discardedByApplicant, discardedByAsru } = require('./status');
 const queryBuilder = require('../query-builders');
 
-const userCreatedThisTask = (c, profile) => {
-  if (!c.data.changedBy) {
+const userCreatedThisTask = (task, profile) => {
+  if (!task.data.changedBy) {
     return false;
   }
 
-  if (typeof c.data.changedBy === 'string') {
-    return c.data.changedBy === profile.id;
+  if (typeof task.data.changedBy === 'string') {
+    return task.data.changedBy === profile.id;
   }
 
-  return c.data.changedBy.id === profile.id;
+  return task.data.changedBy.id === profile.id;
 };
 
-const userIsEstablishmentAdmin = (c, profile) => {
-  const establishmentId = get(c, 'data.establishmentId');
+const userIsEstablishmentAdmin = (task, profile) => {
+  const establishmentId = get(task, 'data.establishmentId');
   const establishment = profile.establishments.find(e => e.id === establishmentId);
   return establishment && establishment.role === 'admin';
 };
@@ -25,37 +25,41 @@ const userIsAsruAdmin = profile => {
   return profile.asruUser && profile.asruAdmin;
 };
 
-const taskIsOpen = c => {
-  return flow.open().includes(c.status);
+const taskIsOpen = task => {
+  return flow.open().includes(task.status);
 };
 
-module.exports = (c, profile) => {
-  if (flow.autoForwards(c.status)) {
-    return Promise.resolve(flow.getNextSteps(c));
+module.exports = (task, profile) => {
+  if (flow.autoForwards(task.status)) {
+    return Promise.resolve(flow.getNextSteps(task));
   }
 
   let nextSteps = [];
 
+  if (task.data.initiatedByAsru && !profile.asruUser) {
+    return Promise.resolve([]);
+  }
+
   // if the task is outstanding for the current user then they can action it
   return queryBuilder({ profile, progress: 'outstanding' })
-    .andWhere('cases.id', c.id)
+    .andWhere('cases.id', task.id)
     .then(cases => cases.results.length > 0)
     .then(taskWithUser => {
       if (taskWithUser) {
-        if (c.data.model === 'pil' && c.data.action === 'transfer' && !userCreatedThisTask(c, profile)) {
-          nextSteps = flow.getNextSteps(c).filter(step => step.id !== updated.id); // prevent edit and resubmit by receiving admin
+        if (task.data.model === 'pil' && task.data.action === 'transfer' && !userCreatedThisTask(task, profile)) {
+          nextSteps = flow.getNextSteps(task).filter(step => step.id !== updated.id); // prevent edit and resubmit by receiving admin
         } else {
-          nextSteps = flow.getNextSteps(c);
+          nextSteps = flow.getNextSteps(task);
         }
       } else {
         // if the task was created by the current user, or if current user is an admin, then they can recall or discard it
-        const canAction = userIsEstablishmentAdmin(c, profile) || userCreatedThisTask(c, profile);
-        if (canAction && flow.getNextSteps(c).length > 0) {
+        const canAction = userIsEstablishmentAdmin(task, profile) || userCreatedThisTask(task, profile);
+        if (canAction && flow.getNextSteps(task).length > 0) {
           nextSteps = [recalledByApplicant, discardedByApplicant];
         }
       }
 
-      if (taskIsOpen(c) && userIsAsruAdmin(profile)) {
+      if (taskIsOpen(task) && userIsAsruAdmin(profile)) {
         nextSteps.push(discardedByAsru);
       }
 

--- a/lib/query-builders/admin.js
+++ b/lib/query-builders/admin.js
@@ -22,7 +22,7 @@ module.exports = {
   outstanding: (queryBuilder, profile) => {
     queryBuilder
       .where(buildEstablishmentQuery(profile))
-      .whereJsonSupersetOf('data', { initiatedByAsru: false })
+      .whereJsonNotSupersetOf('data', { initiatedByAsru: true })
       .whereIn('status', [
         returnedToApplicant.id,
         recalledByApplicant.id

--- a/lib/query-builders/admin.js
+++ b/lib/query-builders/admin.js
@@ -22,6 +22,7 @@ module.exports = {
   outstanding: (queryBuilder, profile) => {
     queryBuilder
       .where(buildEstablishmentQuery(profile))
+      .whereJsonSupersetOf('data', { initiatedByAsru: false })
       .whereIn('status', [
         returnedToApplicant.id,
         recalledByApplicant.id

--- a/lib/query-builders/applicant.js
+++ b/lib/query-builders/applicant.js
@@ -24,7 +24,7 @@ module.exports = {
   myTasks: (queryBuilder, profile) => {
     queryBuilder
       .where(isApplicant(profile))
-      .whereJsonSupersetOf('data', { initiatedByAsru: false })
+      .whereJsonNotSupersetOf('data', { initiatedByAsru: true })
       .whereIn('status', [
         returnedToApplicant.id,
         recalledByApplicant.id
@@ -34,7 +34,7 @@ module.exports = {
   outstanding: (queryBuilder, profile) => {
     queryBuilder
       .where(isApplicant(profile))
-      .whereJsonSupersetOf('data', { initiatedByAsru: false })
+      .whereJsonNotSupersetOf('data', { initiatedByAsru: true })
       .whereIn('status', [
         returnedToApplicant.id,
         recalledByApplicant.id

--- a/lib/query-builders/applicant.js
+++ b/lib/query-builders/applicant.js
@@ -24,6 +24,7 @@ module.exports = {
   myTasks: (queryBuilder, profile) => {
     queryBuilder
       .where(isApplicant(profile))
+      .whereJsonSupersetOf('data', { initiatedByAsru: false })
       .whereIn('status', [
         returnedToApplicant.id,
         recalledByApplicant.id
@@ -33,6 +34,7 @@ module.exports = {
   outstanding: (queryBuilder, profile) => {
     queryBuilder
       .where(isApplicant(profile))
+      .whereJsonSupersetOf('data', { initiatedByAsru: false })
       .whereIn('status', [
         returnedToApplicant.id,
         recalledByApplicant.id

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -5,7 +5,8 @@ module.exports = {
     pil: {
       grant: uuid(),
       rejected: uuid(),
-      transfer: uuid()
+      transfer: uuid(),
+      asruinitiated: uuid()
     },
     place: {
       applied: uuid(),

--- a/test/data/tasks.js
+++ b/test/data/tasks.js
@@ -18,6 +18,7 @@ module.exports = query => query.insert([
       data: {
         name: 'pil with ntco'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: user.id,
       model: 'pil',
@@ -34,6 +35,7 @@ module.exports = query => query.insert([
       data: {
         name: 'pil with ntco - other establishment'
       },
+      initiatedByAsru: false,
       establishmentId: 101,
       subject: uuid(),
       model: 'pil',
@@ -49,6 +51,7 @@ module.exports = query => query.insert([
       data: {
         name: 'pil returned'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: user.id,
       model: 'pil',
@@ -64,6 +67,7 @@ module.exports = query => query.insert([
       data: {
         name: 'pil transfer recalled'
       },
+      initiatedByAsru: false,
       establishmentId: 101,
       subject: userAtMultipleEstablishments.id,
       model: 'pil',
@@ -79,6 +83,7 @@ module.exports = query => query.insert([
       data: {
         name: 'pil with licensing'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: user.id,
       model: 'pil',
@@ -99,6 +104,7 @@ module.exports = query => query.insert([
       meta: {
         authority: 'yes'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: user.id,
       model: 'project',
@@ -114,6 +120,7 @@ module.exports = query => query.insert([
       data: {
         name: 'discarded ppl'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: user.id,
       model: 'project',
@@ -129,6 +136,7 @@ module.exports = query => query.insert([
       data: {
         name: 'place update with licensing'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       model: 'place',
       action: 'update',
@@ -143,6 +151,7 @@ module.exports = query => query.insert([
       data: {
         name: 'place update with licensing - other establishment'
       },
+      initiatedByAsru: false,
       establishmentId: 101,
       model: 'place',
       action: 'update',
@@ -157,6 +166,7 @@ module.exports = query => query.insert([
       data: {
         name: 'place update with inspector'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       model: 'place',
       action: 'update',
@@ -171,6 +181,7 @@ module.exports = query => query.insert([
       data: {
         name: 'place update recommended'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       model: 'place',
       action: 'update',
@@ -186,6 +197,7 @@ module.exports = query => query.insert([
       data: {
         name: 'place update returned'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       model: 'place',
       action: 'update',
@@ -201,6 +213,7 @@ module.exports = query => query.insert([
       data: {
         name: 'place update recommend rejected'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       model: 'place',
       action: 'update',
@@ -215,6 +228,7 @@ module.exports = query => query.insert([
       data: {
         name: 'granted pil'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: user.id,
       model: 'pil',
@@ -230,6 +244,7 @@ module.exports = query => query.insert([
       data: {
         name: 'granted place update'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       model: 'place',
       action: 'update',
@@ -245,6 +260,7 @@ module.exports = query => query.insert([
       data: {
         name: 'granted place update - other establishment'
       },
+      initiatedByAsru: false,
       establishmentId: 101,
       model: 'place',
       action: 'update',
@@ -259,6 +275,7 @@ module.exports = query => query.insert([
       data: {
         name: 'rejected pil'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: uuid(),
       model: 'pil',
@@ -275,6 +292,7 @@ module.exports = query => query.insert([
       data: {
         name: 'profile update'
       },
+      initiatedByAsru: false,
       subject: user.id,
       model: 'profile',
       action: 'update',
@@ -290,6 +308,7 @@ module.exports = query => query.insert([
       data: {
         name: 'conditions update'
       },
+      initiatedByAsru: false,
       model: 'establishment',
       action: 'update-conditions',
       id: 100,
@@ -306,6 +325,7 @@ module.exports = query => query.insert([
       data: {
         name: 'Submitted by HOLC'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       changedBy: holc.id,
       // subject _should_ be the licenceHolderId, but in some cases is not.
@@ -323,6 +343,7 @@ module.exports = query => query.insert([
       data: {
         name: 'another with-inspectorate to test ordering'
       },
+      initiatedByAsru: false,
       establishmentId: 101,
       model: 'place',
       action: 'update',
@@ -337,6 +358,7 @@ module.exports = query => query.insert([
       data: {
         name: 'another with-licensing to test ordering'
       },
+      initiatedByAsru: false,
       establishmentId: 101,
       model: 'place',
       action: 'update',
@@ -351,6 +373,7 @@ module.exports = query => query.insert([
       data: {
         name: 'another with-ntco to test ordering'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: user.id,
       model: 'pil',
@@ -367,6 +390,7 @@ module.exports = query => query.insert([
       data: {
         name: 'users cannot access tasks outside their associated establishments'
       },
+      initiatedByAsru: false,
       establishmentId: 101,
       subject: holc.id,
       model: 'pil',
@@ -383,6 +407,7 @@ module.exports = query => query.insert([
       data: {
         name: 'holc with multiple establishments'
       },
+      initiatedByAsru: false,
       establishmentId: 102,
       model: 'place',
       action: 'update',
@@ -397,6 +422,7 @@ module.exports = query => query.insert([
       data: {
         name: 'project awaiting endorsement'
       },
+      initiatedByAsru: false,
       establishmentId: 100,
       subject: user.id,
       model: 'project',
@@ -406,5 +432,22 @@ module.exports = query => query.insert([
     },
     status: 'awaiting-endorsement',
     ...generateDates(22)
+  },
+  {
+    id: ids.task.pil.asruinitiated,
+    data: {
+      data: {
+        name: 'pil conditions recalled'
+      },
+      initiatedByAsru: true,
+      establishmentId: 100,
+      subject: user.id,
+      model: 'pil',
+      action: 'update-conditions',
+      id: uuid(),
+      changedBy: inspector.id
+    },
+    status: 'recalled-by-applicant',
+    ...generateDates(23)
   }
 ]);

--- a/test/data/tasks.js
+++ b/test/data/tasks.js
@@ -197,7 +197,7 @@ module.exports = query => query.insert([
       data: {
         name: 'place update returned'
       },
-      initiatedByAsru: false,
+      // initiatedByAsru: false, remove to test backwards compat
       establishmentId: 100,
       model: 'place',
       action: 'update',

--- a/test/integration/profile-tasks/index.js
+++ b/test/integration/profile-tasks/index.js
@@ -32,7 +32,8 @@ describe('Subject', () => {
       'pil with licensing',
       'another with-ntco to test ordering',
       'another with-inspectorate to test ordering',
-      'project awaiting endorsement'
+      'project awaiting endorsement',
+      'pil conditions recalled'
     ];
     return request(this.workflow)
       .get(`/profile-tasks/${user.id}`)
@@ -52,7 +53,8 @@ describe('Subject', () => {
       'another with-inspectorate to test ordering',
       'project awaiting endorsement',
       'discarded ppl',
-      'granted pil'
+      'granted pil',
+      'pil conditions recalled'
     ];
     return request(this.workflow)
       .get(`/profile-tasks/${user.id}?all=true`)

--- a/test/integration/tasks/next-steps.js
+++ b/test/integration/tasks/next-steps.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const request = require('supertest');
 const workflowHelper = require('../../helpers/workflow');
-const { user, userAtMultipleEstablishments, holc101, asruAdmin, licensing } = require('../../data/profiles');
+const { user, holc, userAtMultipleEstablishments, holc101, asruAdmin, licensing } = require('../../data/profiles');
 const { resubmitted, updated, discardedByAsru } = require('../../../lib/flow/status');
 const { get } = require('lodash');
 
@@ -126,6 +126,17 @@ describe('Next steps', () => {
           assert.ok(!response.body.data.nextSteps.find(s => s.id === discardedByAsru.id), 'ASRU Admin should not have a discard task option');
         });
     }));
+  });
+
+  it('does not return any steps for non-ASRU users viewing ASRU initiated tasks', () => {
+    this.workflow.setUser({ profile: holc });
+
+    return request(this.workflow)
+      .get(`/${ids.task.pil.asruinitiated}`)
+      .expect(200)
+      .expect(response => {
+        assert.deepEqual(response.body.data.nextSteps, [], 'HOLC has no options to update the task');
+      });
   });
 
 });


### PR DESCRIPTION
Currently licence holders and admins can discard ASRU initiated tasks, this should not be possible.

Remove all possible next steps for a user if they are not an ASRU user and the task was ASRU initiated. Additionally remove the tasks from their outstanding task lists if they are ASRU initiated.