### PR TITLE
bugfix - activity log

### DIFF
--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -1,17 +1,21 @@
-const moment = require('moment');
+const { get } = require('lodash');
 const Cacheable = require('./cacheable');
 const { autoResolved } = require('../flow/status');
 
-function getStatusFromEvent(event) {
-  return event.split(':').pop();
+function getItemStatus(item) {
+  return item.eventName.split(':').pop();
+}
+
+function getStatusChange(item) {
+  return get(item, 'event.meta.payload.status');
+}
+
+function isDeadlineExtension(item) {
+  return !!get(item, 'event.meta.payload.data.extended');
 }
 
 function filterStatusChanges(item) {
-  return item.eventName.split(':')[0] === 'status';
-}
-
-function isThenish(date, then) {
-  return moment(date).isBetween(moment(then), moment(then).add(5, 'seconds'));
+  return item.eventName.split(':')[0] === 'status' || isDeadlineExtension(item);
 }
 
 module.exports = settings => {
@@ -37,17 +41,19 @@ module.exports = settings => {
         let activityLog = c.activityLog.filter(filterStatusChanges);
 
         activityLog = activityLog.reduceRight((store, item, index) => {
-          if (store.length && isThenish(item.createdAt, store[store.length - 1].createdAt)) {
-            store[store.length - 1].status = getStatusFromEvent(item.eventName);
+          const itemStatus = getItemStatus(item);
+          const statusChange = getStatusChange(item);
+
+          if (store.length && statusChange && statusChange !== itemStatus) {
+            store[store.length - 1].status = itemStatus;
             return store;
           } else {
-            const status = getStatusFromEvent(item.eventName);
             return [
               ...store,
               {
                 ...item,
-                status,
-                action: status
+                status: itemStatus,
+                action: statusChange || itemStatus
               }
             ];
           }

--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -3,7 +3,7 @@ const Cacheable = require('./cacheable');
 const { autoResolved } = require('../flow/status');
 
 function getItemStatus(item) {
-  return item.eventName.split(':').pop();
+  return item && item.eventName.split(':').pop();
 }
 
 function getStatusChange(item) {
@@ -15,8 +15,8 @@ function isDeadlineExtension(item) {
 }
 
 function filterStatusChanges(item) {
-  const [type, , status] = item.eventName.split(':');
-  return (type === 'status' && status !== 'resubmitted') || isDeadlineExtension(item);
+  const type = item.eventName.split(':').shift();
+  return type === 'status' || isDeadlineExtension(item);
 }
 
 module.exports = settings => {
@@ -44,8 +44,15 @@ module.exports = settings => {
         activityLog = activityLog.reduceRight((store, item, index) => {
           const itemStatus = getItemStatus(item);
           const statusChange = getStatusChange(item);
+          const prev = store.length && store[store.length - 1];
+          const wasResubmitted = get(item, 'event.meta.previous') === 'resubmitted';
 
-          if (store.length && statusChange && statusChange !== itemStatus) {
+          const isTransientChange = (statusChange && statusChange !== itemStatus) || wasResubmitted;
+
+          const shouldSquash = prev &&
+            ((item.event.req && item.event.req === prev.event.req) || isTransientChange);
+
+          if (shouldSquash) {
             store[store.length - 1].status = itemStatus;
             return store;
           } else {

--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -15,7 +15,8 @@ function isDeadlineExtension(item) {
 }
 
 function filterStatusChanges(item) {
-  return item.eventName.split(':')[0] === 'status' || isDeadlineExtension(item);
+  const [type, , status] = item.eventName.split(':');
+  return (type === 'status' && status !== 'resubmitted') || isDeadlineExtension(item);
 }
 
 module.exports = settings => {

--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -64,6 +64,7 @@ module.exports = settings => {
           log.changedBy = logChangedBys.find(profile => profile && profile.id === log.changedBy) || {};
           delete log.event.meta.user.access_token;
           return log;
+          // sort by createdAt descending
         }).sort((a, b) => b.createdAt - a.createdAt);
 
         return {

--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -64,7 +64,7 @@ module.exports = settings => {
           log.changedBy = logChangedBys.find(profile => profile && profile.id === log.changedBy) || {};
           delete log.event.meta.user.access_token;
           return log;
-        }).reverse();
+        }).sort((a, b) => b.createdAt - a.createdAt);
 
         return {
           ...c,

--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -1,5 +1,18 @@
+const moment = require('moment');
 const Cacheable = require('./cacheable');
 const { autoResolved } = require('../flow/status');
+
+function getStatusFromEvent(event) {
+  return event.split(':').pop();
+}
+
+function filterStatusChanges(item) {
+  return item.eventName.split(':')[0] === 'status';
+}
+
+function isThenish(date, then) {
+  return moment(date).isBetween(moment(then), moment(then).add(5, 'seconds'));
+}
 
 module.exports = settings => {
 
@@ -21,11 +34,30 @@ module.exports = settings => {
 
     return Promise.all(promises)
       .then(logChangedBys => {
-        const activityLog = c.activityLog.map(log => {
+        let activityLog = c.activityLog.filter(filterStatusChanges);
+
+        activityLog = activityLog.reduceRight((store, item, index) => {
+          if (store.length && isThenish(item.createdAt, store[store.length - 1].createdAt)) {
+            store[store.length - 1].status = getStatusFromEvent(item.eventName);
+            return store;
+          } else {
+            const status = getStatusFromEvent(item.eventName);
+            return [
+              ...store,
+              {
+                ...item,
+                status,
+                action: status
+              }
+            ];
+          }
+        }, []);
+
+        activityLog = activityLog.map(log => {
           log.changedBy = logChangedBys.find(profile => profile && profile.id === log.changedBy) || {};
           delete log.event.meta.user.access_token;
           return log;
-        });
+        }).reverse();
 
         return {
           ...c,

--- a/lib/decorators/filter-comments.js
+++ b/lib/decorators/filter-comments.js
@@ -1,6 +1,10 @@
 const { get } = require('lodash');
+const Cacheable = require('./cacheable');
 
 module.exports = settings => {
+
+  const { Profile } = settings.models;
+  const cache = Cacheable();
 
   return (c, user) => {
     if (!c.activityLog) {
@@ -30,7 +34,7 @@ module.exports = settings => {
 
     const isVisible = comment => {
       if (comment.eventName !== 'comment') {
-        return true;
+        return false;
       }
       const timestamp = comment.createdAt;
 
@@ -50,25 +54,29 @@ module.exports = settings => {
       return user.profile.asruUser ? comment.createdAt > lastASRUAction : comment.createdAt > lastSubmit;
     };
 
-    const activityLog = c.activityLog
-      .filter(activity => {
-        return activity.eventName !== 'comment' || isVisible(activity);
-      })
+    const comments = c.activityLog
+      .filter(activity => isVisible(activity))
       .map(activity => {
-        if (activity.eventName === 'comment') {
-          return {
-            ...activity,
-            isNew: isNew(activity),
-            isMine: user.profile.id === get(activity, 'event.meta.user.profile.id')
-          };
-        }
-        return activity;
+        return {
+          ...activity,
+          isNew: isNew(activity),
+          isMine: user.profile.id === get(activity, 'event.meta.user.profile.id')
+        };
       });
 
-    return {
-      ...c,
-      activityLog
-    };
+    const promises = comments.map(comment => cache.query(Profile, comment.changedBy));
+
+    return Promise.all(promises)
+      .then(commentAuthors => {
+        return {
+          ...c,
+          comments: comments.map(comment => {
+            comment.changedBy = commentAuthors.find(profile => profile && profile.id === comment.changedBy) || {};
+            delete comment.event.meta.user.access_token;
+            return comment;
+          })
+        };
+      });
 
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,9 +1204,9 @@
       }
     },
     "@ukhomeoffice/taskflow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/taskflow/-/taskflow-2.0.1.tgz",
-      "integrity": "sha512-+ei3S982G0oDCz6kXTO8gYPPR4grQ+dekSg2hAi9k2UlnH7RzCxIEHVkyV7NSKUthfBeomvDVVBc8c/OQL3zaw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/taskflow/-/taskflow-2.1.0.tgz",
+      "integrity": "sha512-LEPVY6JcSUJITHqWuXgQNW28+LH9jdXv9Sfa3tSe3QHliE0dGfX9nGGIvNOAHG50ApCpVnUJxiL4mZ5f1LBA3Q==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@asl/schema": "^7.32.2",
     "@asl/service": "^7.13.0",
-    "@ukhomeoffice/taskflow": "^2.0.1",
+    "@ukhomeoffice/taskflow": "^2.1.0",
     "aws-sdk": "^2.270.1",
     "express": "^4.16.4",
     "knex": "^0.20.1",

--- a/test/helpers/history.js
+++ b/test/helpers/history.js
@@ -17,10 +17,23 @@ const History = () => {
   };
 
   return {
+    setReqId: req => {
+      model.req = req;
+    },
     status: (status, user, payloadStatus) => {
       model.activityLog.unshift({
         eventName: `status:${model.status}:${status}`,
-        event: { status, meta: { user, payload: { status: payloadStatus } } },
+        event: {
+          req: model.req,
+          status,
+          meta: {
+            previous: model.status,
+            user,
+            payload: {
+              status: payloadStatus
+            }
+          }
+        },
         createdAt: timestamp()
       });
       model.status = status;

--- a/test/helpers/history.js
+++ b/test/helpers/history.js
@@ -1,0 +1,42 @@
+const flow = require('../../lib/flow');
+
+const History = () => {
+
+  const model = {
+    status: 'new',
+    withASRU: false,
+    createdAt: '2019-09-20T10:00:00.000Z',
+    activityLog: [
+      { eventName: 'create', createdAt: '2019-09-20T10:00:00.000Z' }
+    ]
+  };
+
+  const timestamp = () => {
+    const count = model.activityLog.length;
+    return count < 10 ? `2019-09-20T10:00:0${count}.000Z` : `2019-09-20T10:00:${count}.000Z`;
+  };
+
+  return {
+    status: (status, user, payloadStatus) => {
+      model.activityLog.unshift({
+        eventName: `status:${model.status}:${status}`,
+        event: { status, meta: { user, payload: { status: payloadStatus } } },
+        createdAt: timestamp()
+      });
+      model.status = status;
+      model.withASRU = flow.withASRU().includes(status);
+    },
+    comment: (comment, user) => {
+      model.activityLog.unshift({
+        eventName: 'comment',
+        comment,
+        event: { meta: { user } },
+        createdAt: timestamp()
+      });
+    },
+    model
+  };
+
+};
+
+module.exports = History;

--- a/test/unit/decorators/activity-log.js
+++ b/test/unit/decorators/activity-log.js
@@ -1,0 +1,59 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const decorator = require('../../../lib/decorators/activity-log');
+const History = require('../../helpers/history');
+
+let task;
+
+const settings = {
+  models: {
+    Profile: {
+      queryWithDeleted: sinon.stub().returns({
+        findById: sinon.stub().returns({
+          then: sinon.stub().returns([])
+        })
+      })
+    }
+  }
+};
+
+const runDecorator = decorator(settings);
+
+const users = {
+  anon: { },
+  asru: { profile: { asruUser: true } },
+  external: { profile: { asruUser: false } }
+};
+
+describe('Activity log', () => {
+  beforeEach(() => {
+    task = History();
+  });
+
+  it('filters out comments', () => {
+    task.status('with-inspectorate', users.external);
+    task.comment('one', users.asru);
+    task.comment('two', users.asru);
+    return Promise.resolve()
+      .then(() => runDecorator(task.model))
+      .then(({ activityLog }) => {
+        assert.equal(activityLog.length, 1);
+        assert.equal(activityLog[0].action, 'with-inspectorate');
+        assert.equal(activityLog[0].status, 'with-inspectorate');
+      });
+  });
+
+  it('groups together autoforwarding status changes', () => {
+    task.status('awaiting-endorsement', users.external);
+    task.status('endorsed', users.external, 'endorsed');
+    // autoforward to awaiting endorsement
+    task.status('awaiting-endorsement', users.external, 'endorsed');
+    return Promise.resolve()
+      .then(() => runDecorator(task.model))
+      .then(({ activityLog }) => {
+        assert.equal(activityLog.length, 2);
+        assert.equal(activityLog[1].action, 'endorsed');
+        assert.equal(activityLog[1].status, 'awaiting-endorsement');
+      });
+  });
+});

--- a/test/unit/decorators/filter-comments.js
+++ b/test/unit/decorators/filter-comments.js
@@ -1,46 +1,8 @@
 const assert = require('assert');
+const sinon = require('sinon');
 
-const flow = require('../../../lib/flow');
 const decorator = require('../../../lib/decorators/filter-comments');
-
-const History = () => {
-
-  const model = {
-    status: 'new',
-    withASRU: false,
-    createdAt: '2019-09-20T10:00:00.000Z',
-    activityLog: [
-      { eventName: 'create', createdAt: '2019-09-20T10:00:00.000Z' }
-    ]
-  };
-
-  const timestamp = () => {
-    const count = model.activityLog.length;
-    return count < 10 ? `2019-09-20T10:00:0${count}.000Z` : `2019-09-20T10:00:${count}.000Z`;
-  };
-
-  return {
-    status: (status, user) => {
-      model.activityLog.push({
-        eventName: `status:${model.status}:${status}`,
-        event: { status, meta: { user } },
-        createdAt: timestamp()
-      });
-      model.status = status;
-      model.withASRU = flow.withASRU().includes(status);
-    },
-    comment: (comment, user) => {
-      model.activityLog.push({
-        eventName: 'comment',
-        comment,
-        event: { meta: { user } },
-        createdAt: timestamp()
-      });
-    },
-    model
-  };
-
-};
+const History = require('../../helpers/history');
 
 const users = {
   anon: { },
@@ -48,9 +10,20 @@ const users = {
   external: { profile: { asruUser: false } }
 };
 
-const assertComments = (task, user, expected) => {
-  const result = decorator()(task.model, user);
-  const comments = result.activityLog.filter(a => a.eventName === 'comment');
+const assertComments = async (task, user, expected) => {
+  const settings = {
+    models: {
+      Profile: {
+        queryWithDeleted: sinon.stub().returns({
+          findById: sinon.stub().returns({
+            then: sinon.stub().returns([])
+          })
+        })
+      }
+    }
+  };
+  const result = await decorator(settings)(task.model, user);
+  const comments = result.comments;
   assert.equal(comments.length, expected.length);
   assert.deepEqual(comments.map(c => c.comment), expected);
 };


### PR DESCRIPTION
* only include status change events and deadline updates
~* if multiple events happened within 5 secs, group taking the action from the first event, and the status from the last~
* check the status change sent in the request, if the end status of the activity log item doesn't match then group with the next item and show the status sent (action) and the end status (status)
