### PR TITLE
Remove first query to changelog when polling

### DIFF
--- a/lib/messager/index.js
+++ b/lib/messager/index.js
@@ -14,27 +14,29 @@ module.exports = settings => {
   const POLL_TIMEOUT = settings.sqs.pollTimeout;
   const POLL_INTERVAL = settings.sqs.pollInterval;
 
+  const wait = t => new Promise(resolve => setTimeout(resolve, t));
+
   const pollChangelog = id => {
     const endTime = Number(new Date()) + POLL_TIMEOUT;
 
-    const checkCondition = (resolve, reject) => {
-      console.log(`Polling changelog for: ${id}`);
-      Promise.resolve()
+    const checkCondition = () => {
+      return wait(POLL_INTERVAL)
+        .then(() => console.log(`Polling changelog for: ${id}`))
         .then(() => Changelog.query().findById(id))
         .then(model => {
           if (model) {
             if (model.action === 'error') {
-              return reject(new Error(model.state.message || 'Resolver failed'));
+              throw new Error(model.state.message || 'Resolver failed');
             }
-            return resolve(model);
+            return model;
           } else if (Number(new Date()) < endTime) {
-            setTimeout(checkCondition, POLL_INTERVAL, resolve, reject);
+            return checkCondition();
           } else {
-            return reject(new TimeoutError());
+            throw new TimeoutError();
           }
         });
     };
-    return new Promise(checkCondition);
+    return checkCondition();
   };
 
   if (settings.noDownstream) {


### PR DESCRIPTION
The first query _never_ returns a match as it is performed immediately after sending the message. Add an initial wait before checking the changelog for the first time.

Also refactor the promises to be a bit cleaner by extracting the `wait` into a separate function.