### PR TITLE
Scope test db teardown methods to an instance

### DIFF
--- a/test/integration/establishment/conditions.js
+++ b/test/integration/establishment/conditions.js
@@ -12,12 +12,12 @@ describe('Update conditions', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('can be created even if an open task for the establishment exists', () => {

--- a/test/integration/establishment/grant.js
+++ b/test/integration/establishment/grant.js
@@ -17,12 +17,12 @@ describe('Establishment grant', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('sends grant requests to the inspectorate', () => {
@@ -56,7 +56,7 @@ describe('Establishment grant', () => {
         status: withInspectorate.id
       }
     ];
-    return workflowHelper.seedTaskList(existing)
+    return this.workflow.seedTaskList(existing)
       .then(() => {
         return request(this.workflow)
           .post('/')
@@ -94,7 +94,7 @@ describe('Establishment grant', () => {
         status: withInspectorate.id
       }
     ];
-    return workflowHelper.seedTaskList(existing)
+    return this.workflow.seedTaskList(existing)
       .then(() => {
         return request(this.workflow)
           .post('/')

--- a/test/integration/establishment/revoke.js
+++ b/test/integration/establishment/revoke.js
@@ -17,12 +17,12 @@ describe('Establishment revoke', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('holcs cannot revoke establishment licences', () => {

--- a/test/integration/establishment/update-billing.js
+++ b/test/integration/establishment/update-billing.js
@@ -12,12 +12,12 @@ describe('Update billing', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('can be created even if an open task for the establishment exists', () => {

--- a/test/integration/fee-waiver/index.js
+++ b/test/integration/fee-waiver/index.js
@@ -13,12 +13,12 @@ describe('Fee waiver', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('can be created even if an open task for the PIL exists', () => {

--- a/test/integration/hooks/model-data.js
+++ b/test/integration/hooks/model-data.js
@@ -14,12 +14,12 @@ describe('Model data hook', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('Establishment', () => {
@@ -115,7 +115,7 @@ describe('Model data hook', () => {
         .then(response => response.body.data)
         .then(task => {
           assert.equal(task.data.modelData.name, 'Has assigned roles');
-          const role = task.data.modelData.roles[0]
+          const role = task.data.modelData.roles[0];
           assert.equal(role.type, 'nacwo');
           assert.equal(role.profile.firstName, 'Clive');
         });

--- a/test/integration/hooks/unique.js
+++ b/test/integration/hooks/unique.js
@@ -15,12 +15,12 @@ describe('unique hook', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('rejects if creating a task where one already exists and is noto with the user', () => {

--- a/test/integration/pil/review.js
+++ b/test/integration/pil/review.js
@@ -15,12 +15,12 @@ describe('PIL Review', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('resolves if submitted by an NTCO', () => {

--- a/test/integration/pil/transfer.js
+++ b/test/integration/pil/transfer.js
@@ -15,12 +15,12 @@ describe('PIL transfer', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('prevents transfer by anyone other than the owner of the PIL', () => {

--- a/test/integration/place/update.js
+++ b/test/integration/place/update.js
@@ -27,12 +27,12 @@ describe('Place update', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('autoresolves updates by external users that only modify the assigned roles', () => {

--- a/test/integration/profile-tasks/index.js
+++ b/test/integration/profile-tasks/index.js
@@ -16,12 +16,12 @@ describe('Subject', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('returns open tasks where user is the subject or opened the task', () => {

--- a/test/integration/profile/update.js
+++ b/test/integration/profile/update.js
@@ -15,12 +15,12 @@ describe('Profile update', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('create profile', () => {

--- a/test/integration/project/continuation.js
+++ b/test/integration/project/continuation.js
@@ -15,12 +15,12 @@ describe('Project continuation', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('adds a continuation property to task data', () => {

--- a/test/integration/project/create-legacy-stub.js
+++ b/test/integration/project/create-legacy-stub.js
@@ -14,11 +14,11 @@ describe('Project create legacy stub', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs());
+      .then(() => this.workflow.resetDBs());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('prevents project stubs being created by external users', () => {

--- a/test/integration/project/transfer.js
+++ b/test/integration/project/transfer.js
@@ -26,12 +26,12 @@ describe('Project transfer', () => {
       }
     };
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('updates the action to `transfer` and adds the transferToEstablishment to data, and to and from establishments to meta', () => {

--- a/test/integration/project/update-issue-date.js
+++ b/test/integration/project/update-issue-date.js
@@ -15,12 +15,12 @@ describe('Project update issue date', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('prevents issue date being updated by the licence holder', () => {

--- a/test/integration/project/update-licence-holder.js
+++ b/test/integration/project/update-licence-holder.js
@@ -15,12 +15,12 @@ describe('Project update licence holder', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('autoresolves licence holder updates to stubs by a licensing officer', () => {

--- a/test/integration/project/update-licence-number.js
+++ b/test/integration/project/update-licence-number.js
@@ -15,12 +15,12 @@ describe('Project stub update licence number', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('prevents licence number being updated by the licence holder', () => {

--- a/test/integration/task-lists/applicant.js
+++ b/test/integration/task-lists/applicant.js
@@ -18,12 +18,12 @@ describe('Applicant', () => {
     this.workflow.setUser({ profile: user });
 
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('outstanding tasks', () => {

--- a/test/integration/task-lists/error-states.js
+++ b/test/integration/task-lists/error-states.js
@@ -15,12 +15,12 @@ describe('Task list error states', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('returns an empty list if no profile is found', () => {

--- a/test/integration/task-lists/establishment-admin.js
+++ b/test/integration/task-lists/establishment-admin.js
@@ -18,12 +18,12 @@ describe('Establishment Admin', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('outstanding tasks', () => {

--- a/test/integration/task-lists/inspector.js
+++ b/test/integration/task-lists/inspector.js
@@ -18,12 +18,12 @@ describe('Inspector', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('my tasks', () => {

--- a/test/integration/task-lists/licensing.js
+++ b/test/integration/task-lists/licensing.js
@@ -18,12 +18,12 @@ describe('Licensing Officer', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('my tasks', () => {

--- a/test/integration/task-lists/ntco.js
+++ b/test/integration/task-lists/ntco.js
@@ -17,12 +17,12 @@ describe('NTCO', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('outstanding tasks', () => {

--- a/test/integration/tasks-for-model/index.js
+++ b/test/integration/tasks-for-model/index.js
@@ -15,12 +15,12 @@ describe('Tasks for a model', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('outstanding tasks', () => {

--- a/test/integration/tasks/applicant.js
+++ b/test/integration/tasks/applicant.js
@@ -27,12 +27,12 @@ describe('Applicant', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('creating tasks', () => {

--- a/test/integration/tasks/asru-admin.js
+++ b/test/integration/tasks/asru-admin.js
@@ -15,12 +15,12 @@ describe('ASRU Admins', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('Open tasks', () => {

--- a/test/integration/tasks/establishment-admin.js
+++ b/test/integration/tasks/establishment-admin.js
@@ -23,12 +23,12 @@ describe('Establishment Admin', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('outstanding tasks', () => {

--- a/test/integration/tasks/next-steps.js
+++ b/test/integration/tasks/next-steps.js
@@ -18,12 +18,12 @@ describe('Next steps', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   it('resubmitted appears as an option on a pil.grant task', () => {

--- a/test/integration/tasks/ntco.js
+++ b/test/integration/tasks/ntco.js
@@ -26,12 +26,12 @@ describe('NTCO', () => {
 
   beforeEach(() => {
     return Promise.resolve()
-      .then(() => workflowHelper.resetDBs())
-      .then(() => workflowHelper.seedTaskList());
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
   });
 
   after(() => {
-    return workflowHelper.destroy();
+    return this.workflow.destroy();
   });
 
   describe('outstanding tasks', () => {


### PR DESCRIPTION
Previously a single global reference to an instance was maintained and teardown methods pointed only to this insitance, and would leave behind others.

By scoping the teardown and seed methods to each instance then we can ensure that all instances are correctly removed.