### PR TITLE
Add endpoint for accessing basic status configuration

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -16,6 +16,7 @@ const tasksRouter = require('./router/tasks');
 const openTasksRouter = require('./router/open-tasks');
 const relatedTasksRouter = require('./router/related-tasks');
 const metricsRouter = require('./router/metrics');
+const flowRouter = require('./router/flow');
 
 const decorators = require('./decorators');
 
@@ -46,6 +47,8 @@ module.exports = settings => {
   const models = schema(settings.db);
   settings.models = models;
   app.models = models;
+
+  app.use('/flow', flowRouter(settings));
 
   app.use(profile(settings));
 

--- a/lib/router/flow.js
+++ b/lib/router/flow.js
@@ -1,0 +1,25 @@
+const { Router } = require('express');
+const flow = require('../flow');
+
+module.exports = () => {
+  const router = Router();
+
+  router.get('/', (req, res, next) => {
+
+    const open = flow.open();
+    const statuses = flow.getAllSteps().reduce((map, status) => {
+      return {
+        ...map,
+        [status.id]: {
+          open: open.includes(status.id),
+          withASRU: !!status.withASRU
+        }
+      };
+    }, {});
+
+    res.json(statuses);
+
+  });
+
+  return router;
+};


### PR DESCRIPTION
This allows other services to load accurate and up-to-date information about the workflow service's statuses without needing to duplicate configuration or create complex dependency chains.