### PR TITLE
Allow removing HOLCs

### DIFF
--- a/lib/flow/status.js
+++ b/lib/flow/status.js
@@ -19,8 +19,9 @@ function isNtcoReview(task) {
 }
 
 function isHolcAssignment(task) {
+  const action = get(task, 'data.action');
   return get(task, 'data.model') === 'role' &&
-    get(task, 'data.action') === 'create' &&
+    ['create', 'delete'].includes(action) &&
     get(task, 'data.data.type') === 'holc';
 }
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Workflow API for processing change requests",
   "main": "index.js",
   "scripts": {
-    "test": "npm run test:lint && npm run test:unit",
+    "test": "npm run test:lint && npm run test:integration && npm run test:unit",
     "test:lint": "eslint .",
-    "test:unit": "NODE_ENV=test npm run migrate:test && mocha ./test",
+    "test:integration": "NODE_ENV=test npm run migrate:test && mocha ./test/integration",
+    "test:unit": "mocha ./test/unit",
     "dev": "nodemon -r dotenv/config index.js",
     "seed": "SNAKE_MAPPER=true knex seed:run",
     "migrate": "node ./scripts/migrate.js",

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -475,7 +475,7 @@ module.exports = models => {
               establishmentId: 101
             },
             {
-              id: uuid(),
+              id: ids.model.role.holc,
               type: 'holc',
               profileId: '143e500a-d42d-4010-840e-35418660cdc2',
               establishmentId: 101

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -41,7 +41,8 @@ module.exports = {
     },
     role: {
       nacwoClive: uuid(),
-      nacwoDerek: uuid()
+      nacwoDerek: uuid(),
+      holc: uuid()
     },
     project: {
       grant: uuid(),

--- a/test/integration/role/holc.js
+++ b/test/integration/role/holc.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+const assert = require('assert');
+const workflowHelper = require('../../helpers/workflow');
+const { user } = require('../../data/profiles');
+const ids = require('../../data/ids');
+const { resolved } = require('../../../lib/flow/status');
+
+describe('Add/remove HOLCs', () => {
+  before(() => {
+    return workflowHelper.create()
+      .then(workflow => {
+        this.workflow = workflow;
+        this.workflow.setUser({ profile: user });
+      });
+  });
+
+  beforeEach(() => {
+    return Promise.resolve()
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
+  });
+
+  after(() => {
+    return this.workflow.destroy();
+  });
+
+  describe('create HOLC', () => {
+    it('sets status to resolved', () => {
+      return request(this.workflow)
+        .post('/')
+        .send({
+          model: 'role',
+          action: 'create',
+          data: {
+            type: 'holc'
+          }
+        })
+        .expect(200)
+        .then(response => response.body.data)
+        .then(task => {
+          assert.equal(task.status, resolved.id);
+        });
+    });
+  });
+
+  describe('delete HOLC', () => {
+    it('sets status to resolved', () => {
+      return request(this.workflow)
+        .post('/')
+        .send({
+          model: 'role',
+          action: 'delete',
+          id: ids.model.role.holc,
+          data: {
+            type: 'holc'
+          }
+        })
+        .expect(200)
+        .then(response => response.body.data)
+        .then(task => {
+          assert.equal(task.status, resolved.id);
+        });
+    });
+  });
+
+});

--- a/test/unit/hooks/create/role.js
+++ b/test/unit/hooks/create/role.js
@@ -4,6 +4,7 @@ const { withLicensing, withInspectorate, resolved } = require('../../../../lib/f
 const hook = require('../../../../lib/hooks/create/role');
 const Database = require('../../../helpers/asl-db');
 const fixtures = require('../../../data');
+const ids = require('../../../data/ids');
 
 const settings = require('../../../helpers/database-settings');
 
@@ -48,6 +49,18 @@ describe('Role create hook', () => {
 
   it('resolves if the role is holc', () => {
     this.model.data.data.type = 'holc';
+    return Promise.resolve()
+      .then(() => this.hook(this.model))
+      .then(() => {
+        assert.ok(this.model.setStatus.calledOnce);
+        assert.equal(this.model.setStatus.lastCall.args[0], resolved.id);
+      });
+  });
+
+  it('resolves if the role is holc and the action is delete', () => {
+    this.model.data.data.type = 'holc';
+    this.model.data.action = 'delete';
+    this.model.data.id = ids.model.role.holc;
     return Promise.resolve()
       .then(() => this.hook(this.model))
       .then(() => {


### PR DESCRIPTION
The check for moving things into "resolved" status was only testing if the task was creating a HOLC, but removing a HOLC should also resolve.

Allow both create and delete actions on HOLC roles to resolve.