### PR TITLE
Set modelData when deleting roles

### DIFF
--- a/lib/flow/status.js
+++ b/lib/flow/status.js
@@ -19,14 +19,16 @@ function isNtcoReview(task) {
 }
 
 function isHolcAssignment(task) {
-  const action = get(task, 'data.action');
-  // the role will either be on the top level task data or the modelData depending on whether
-  // the task is a create or a delete
-  const path = action === 'create' ? 'data.data.type' : 'data.modelData.type';
-  const role = get(task, path);
-  return get(task, 'data.model') === 'role' &&
-    ['create', 'delete'].includes(action) &&
-    role === 'holc';
+  const model = get(task, 'data.model');
+  if (model === 'role') {
+    const action = get(task, 'data.action');
+    // the role will either be on the top level task data or the modelData depending on whether
+    // the task is a create or a delete
+    const path = action === 'create' ? 'data.data.type' : 'data.modelData.type';
+    const role = get(task, path);
+    return role === 'holc';
+  }
+  return false;
 }
 
 module.exports = {

--- a/lib/flow/status.js
+++ b/lib/flow/status.js
@@ -20,9 +20,13 @@ function isNtcoReview(task) {
 
 function isHolcAssignment(task) {
   const action = get(task, 'data.action');
+  // the role will either be on the top level task data or the modelData depending on whether
+  // the task is a create or a delete
+  const path = action === 'create' ? 'data.data.type' : 'data.modelData.type';
+  const role = get(task, path);
   return get(task, 'data.model') === 'role' &&
     ['create', 'delete'].includes(action) &&
-    get(task, 'data.data.type') === 'holc';
+    role === 'holc';
 }
 
 module.exports = {

--- a/lib/hooks/model-data/index.js
+++ b/lib/hooks/model-data/index.js
@@ -1,7 +1,7 @@
 const { get } = require('lodash');
 
 module.exports = settings => {
-  const { Place, Establishment, Project, PIL, Profile } = settings.models;
+  const { Place, Establishment, Project, PIL, Profile, Role } = settings.models;
 
   function constrainProfileParams(builder) {
     return builder.select('firstName', 'lastName', 'id');
@@ -27,6 +27,8 @@ module.exports = settings => {
           .modifiers({ constrainProfileParams });
       case 'profile':
         return Profile.query().findById(id);
+      case 'role':
+        return Role.query().findById(id);
     }
   }
 

--- a/test/integration/role/delete.js
+++ b/test/integration/role/delete.js
@@ -1,0 +1,59 @@
+const request = require('supertest');
+const assert = require('assert');
+const workflowHelper = require('../../helpers/workflow');
+const { holc } = require('../../data/profiles');
+const ids = require('../../data/ids');
+const { withInspectorate } = require('../../../lib/flow/status');
+
+describe('Removing roles', () => {
+  before(() => {
+    return workflowHelper.create()
+      .then(workflow => {
+        this.workflow = workflow;
+        this.workflow.setUser({ profile: holc });
+      });
+  });
+
+  beforeEach(() => {
+    return Promise.resolve()
+      .then(() => this.workflow.resetDBs())
+      .then(() => this.workflow.seedTaskList());
+  });
+
+  after(() => {
+    return this.workflow.destroy();
+  });
+
+  it('assigns task to an inspector', () => {
+    return request(this.workflow)
+      .post('/')
+      .send({
+        model: 'role',
+        action: 'delete',
+        id: ids.model.role.nacwoClive,
+        changedBy: holc.id
+      })
+      .expect(200)
+      .then(response => response.body.data)
+      .then(task => {
+        assert.equal(task.status, withInspectorate.id);
+      });
+  });
+
+  it('includes model data on task', () => {
+    return request(this.workflow)
+      .post('/')
+      .send({
+        model: 'role',
+        action: 'delete',
+        id: ids.model.role.nacwoClive,
+        changedBy: holc.id
+      })
+      .expect(200)
+      .then(response => response.body.data)
+      .then(task => {
+        assert.equal(task.data.modelData.type, 'nacwo');
+      });
+  });
+
+});

--- a/test/integration/role/holc.js
+++ b/test/integration/role/holc.js
@@ -1,7 +1,7 @@
 const request = require('supertest');
 const assert = require('assert');
 const workflowHelper = require('../../helpers/workflow');
-const { user } = require('../../data/profiles');
+const { holc } = require('../../data/profiles');
 const ids = require('../../data/ids');
 const { resolved } = require('../../../lib/flow/status');
 
@@ -10,7 +10,7 @@ describe('Add/remove HOLCs', () => {
     return workflowHelper.create()
       .then(workflow => {
         this.workflow = workflow;
-        this.workflow.setUser({ profile: user });
+        this.workflow.setUser({ profile: holc });
       });
   });
 
@@ -50,10 +50,7 @@ describe('Add/remove HOLCs', () => {
         .send({
           model: 'role',
           action: 'delete',
-          id: ids.model.role.holc,
-          data: {
-            type: 'holc'
-          }
+          id: ids.model.role.holc
         })
         .expect(200)
         .then(response => response.body.data)


### PR DESCRIPTION
This was not previously being set on tasks, but is needed to handle the UI for removing multiple roles at the same time.