### PR TITLE
Fix query builder for generic ASRU user

### DIFF
--- a/lib/query-builders/asru.js
+++ b/lib/query-builders/asru.js
@@ -31,7 +31,7 @@ module.exports = {
       rejected.id,
       withdrawnByApplicant.id,
       discardedByApplicant.id,
-      discardedByAsru
+      discardedByAsru.id
     ]);
   }
 

--- a/test/data/tasks.js
+++ b/test/data/tasks.js
@@ -11,7 +11,7 @@ const generateDates = daysAgo => {
   };
 };
 
-module.exports = query => query.insert([
+const tasks = [
   {
     id: ids.task.pil.withNtco,
     data: {
@@ -683,5 +683,23 @@ module.exports = query => query.insert([
     },
     status: 'resolved',
     ...generateDates(34)
+  },
+  {
+    id: uuid(),
+    data: {
+      data: {
+        name: 'discarded by asru'
+      },
+      initiatedByAsru: false,
+      establishmentId: 100,
+      subject: holc.id,
+      model: 'project',
+      action: 'grant',
+      changedBy: holc.id
+    },
+    status: 'discarded-by-asru',
+    ...generateDates(34)
   }
-]);
+];
+
+module.exports = tasks;

--- a/test/helpers/assert-tasks.js
+++ b/test/helpers/assert-tasks.js
@@ -1,7 +1,14 @@
 const assert = require('assert');
+const { difference } = require('lodash');
+const seeds = require('../data/tasks');
 
 module.exports = (expected, actual) => {
-  assert.equal(actual.length, expected.length, `Expected ${expected.length} records. Received ${actual.length}`);
   const names = actual.map(task => task.data.data.name);
-  names.forEach(name => assert(expected.includes(name), `Expected [${expected.join(', ')}] to include "${name}"`));
+  const all = seeds.map(task => task.data.data.name);
+  const nopes = difference(all, names);
+
+  names.forEach(name => assert(expected.includes(name), `[${expected.join(', ')}] should include "${name}"`));
+  nopes.forEach(name => assert(!names.includes(name), `[${actual.join(', ')}] should not include "${name}"`));
+
+  assert.equal(actual.length, expected.length, `Expected ${expected.length} records. Received ${actual.length}`);
 };

--- a/test/helpers/taskflow-db.js
+++ b/test/helpers/taskflow-db.js
@@ -13,7 +13,7 @@ module.exports = knex => {
       }),
     seed: (tasks = []) => Promise.resolve()
       .then(() => {
-        return seeds(Task.query(knex));
+        return Task.query(knex).insert(seeds);
       })
       .then(() => {
         if (tasks.length) {

--- a/test/integration/related-tasks/index.js
+++ b/test/integration/related-tasks/index.js
@@ -264,7 +264,8 @@ describe('Related tasks', () => {
           'holc pil with licensing',
           'holc owned project',
           'granted establishment update',
-          'granted nio role at croydon'
+          'granted nio role at croydon',
+          'discarded by asru'
         ];
 
         return request(this.workflow)

--- a/test/integration/task-lists/applicant.js
+++ b/test/integration/task-lists/applicant.js
@@ -121,7 +121,11 @@ describe('Applicant', () => {
   describe('completed tasks', () => {
 
     it('sees tasks for which they are the subject', () => {
-      const expected = [ 'granted pil', 'discarded ppl', 'profile update' ];
+      const expected = [
+        'granted pil',
+        'discarded ppl',
+        'profile update'
+      ];
       return request(this.workflow)
         .get('/?progress=completed')
         .expect(200)
@@ -140,7 +144,9 @@ describe('Applicant', () => {
     });
 
     it('can filter by licence type of ppl', () => {
-      const projectTasks = ['discarded ppl'];
+      const projectTasks = [
+        'discarded ppl'
+      ];
 
       return request(this.workflow)
         .get('/?progress=completed&filters%5Blicence%5D%5B0%5D=ppl')

--- a/test/integration/task-lists/asru.js
+++ b/test/integration/task-lists/asru.js
@@ -4,15 +4,15 @@ const assertTasks = require('../../helpers/assert-tasks');
 const assertTaskOrder = require('../../helpers/assert-task-order');
 const workflowHelper = require('../../helpers/workflow');
 
-const { licensing } = require('../../data/profiles');
+const { asruAdmin } = require('../../data/profiles');
 
-describe('Licensing Officer', () => {
+describe('ASRU user - neither inspector nor LO', () => {
 
   before(() => {
     return workflowHelper.create()
       .then(workflow => {
         this.workflow = workflow;
-        this.workflow.setUser({ profile: licensing });
+        this.workflow.setUser({ profile: asruAdmin });
       });
   });
 
@@ -26,93 +26,26 @@ describe('Licensing Officer', () => {
     return this.workflow.destroy();
   });
 
-  describe('my tasks', () => {
+  describe('in progress tasks', () => {
 
-    it('sees tasks with correct statuses and establishments', () => {
-      const expected = [
-        'place update with licensing - other establishment',
-        'another with-licensing to test ordering'
-      ];
-      return request(this.workflow)
-        .get('/?progress=myTasks')
-        .expect(200)
-        .expect(response => {
-          assertTasks(expected, response.body.data);
-        });
-    });
-
-    it('sorts the tasks by oldest first', () => {
-      return request(this.workflow)
-        .get('/?progress=myTasks')
-        .expect(200)
-        .expect(response => {
-          assertTaskOrder(response.body.data, 'ascending');
-        });
-    });
-
-  });
-
-  describe('outstanding tasks', () => {
-
-    it('sees tasks with correct statuses', () => {
-      const expected = [
-        'pil with licensing',
-        'place update with licensing',
-        'place update with licensing - other establishment',
-        'place update recommended',
-        'place update recommend rejected',
-        'another with-licensing to test ordering',
-        'holc pil with licensing'
-      ];
-      return request(this.workflow)
-        .get('/')
-        .expect(200)
-        .expect(response => {
-          assertTasks(expected, response.body.data);
-        });
-    });
-
-    it('sorts the tasks by oldest first', () => {
-      return request(this.workflow)
-        .get('/')
-        .expect(200)
-        .expect(response => {
-          assertTaskOrder(response.body.data, 'ascending');
-        });
-    });
-
-    it('can filter by licence type of pel', () => {
-      const pelTasks = [
-        'place update with licensing',
-        'place update with licensing - other establishment',
-        'place update recommended',
-        'place update recommend rejected',
-        'another with-licensing to test ordering'
-      ];
-
-      return request(this.workflow)
-        .get('/?filters%5Blicence%5D%5B0%5D=pel')
-        .expect(200)
-        .expect(response => {
-          assertTasks(pelTasks, response.body.data);
-        });
-    });
-
-  });
-
-  describe('in-progress tasks', () => {
-
-    it('sees tasks that are with inspectors or returned to establishments', () => {
+    it('sees tasks with appropriate statuses', () => {
       const expected = [
         'pil returned',
         'pil transfer recalled',
+        'pil with licensing',
+        'place update with licensing',
+        'place update with licensing - other establishment',
         'place update with inspector',
+        'place update recommended',
         'place update returned',
+        'place update recommend rejected',
         'conditions update',
         'Submitted by HOLC',
         'another with-inspectorate to test ordering',
+        'another with-licensing to test ordering',
         'holc with multiple establishments',
         'ppl submitted by HOLC for user',
+        'holc pil with licensing',
         'holc owned project'
       ];
       return request(this.workflow)

--- a/test/integration/task-lists/establishment-admin.js
+++ b/test/integration/task-lists/establishment-admin.js
@@ -104,6 +104,7 @@ describe('Establishment Admin', () => {
         'granted place update',
         'rejected pil',
         'discarded ppl',
+        'discarded by asru',
         'profile update holc',
         'granted establishment update',
         'granted nio role at croydon'

--- a/test/integration/task-lists/inspector.js
+++ b/test/integration/task-lists/inspector.js
@@ -129,6 +129,7 @@ describe('Inspector', () => {
         'granted place update - other establishment',
         'rejected pil',
         'discarded ppl',
+        'discarded by asru',
         'profile update',
         'profile update holc',
         'profile update user101',


### PR DESCRIPTION
It was not specifying the id correctly for `discarded-by-asru`.

Refactor task tests so that they better assert on tasks which are not present in a result set.