### PR TITLE
Mark LO PPL revocations as resolved

### DIFF
--- a/lib/hooks/create/project.js
+++ b/lib/hooks/create/project.js
@@ -1,7 +1,14 @@
 const { get } = require('lodash');
 const { ref } = require('objection');
 const { UnauthorisedError } = require('@asl/service/errors');
-const { autoResolved, withLicensing, awaitingEndorsement, endorsed, withInspectorate } = require('../../flow/status');
+const {
+  resolved,
+  autoResolved,
+  withLicensing,
+  awaitingEndorsement,
+  endorsed,
+  withInspectorate
+} = require('../../flow/status');
 const { canEndorse } = require('../../util');
 
 const Messager = require('../../messager');
@@ -139,7 +146,7 @@ module.exports = settings => {
 
             if (profile.asruUser && profile.asruLicensing) {
               // Project revoked by licensing, does not need review
-              return model.setStatus(autoResolved.id);
+              return model.setStatus(resolved.id);
             }
 
             // Project revoked by other asru user - needs licensing review

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -317,6 +317,20 @@ module.exports = models => {
                 ]
               },
               {
+                id: ids.model.project.revoke,
+                title: 'Test revocation project',
+                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                issueDate: '2020-01-01T12:00:00Z',
+                expiryDate: '2025-01-01T12:00:00Z',
+                licenceNumber: '70/1235',
+                version: [
+                  {
+                    id: uuid(),
+                    status: 'granted'
+                  }
+                ]
+              },
+              {
                 id: ids.model.project.continuation,
                 title: 'Test project 9',
                 licenceHolderId: user.id,

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -47,6 +47,7 @@ module.exports = {
     project: {
       grant: uuid(),
       transfer: uuid(),
+      revoke: uuid(),
       recalledTransfer: uuid(),
       updateIssueDate: uuid(),
       updateLicenceNumber: uuid(),

--- a/test/unit/hooks/create/project.js
+++ b/test/unit/hooks/create/project.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { withLicensing, withInspectorate, resolved } = require('../../../../lib/flow/status');
+const hook = require('../../../../lib/hooks/create/role');
+const Database = require('../../../helpers/asl-db');
+const fixtures = require('../../../data');
+const ids = require('../../../data/ids');
+
+const settings = require('../../../helpers/database-settings');
+
+const INSPECTOR_ID = 'a942ffc7-e7ca-4d76-a001-0b5048a057d1';
+const LICENSING_ID = 'a942ffc7-e7ca-4d76-a001-0b5048a057d2';
+const PELH_ID = 'ae28fb31-d867-4371-9b4f-79019e71232f';
+
+describe('Project create hook', () => {
+  before(() => {
+    return Database(settings.db).init(fixtures.default, true)
+      .then(models => {
+        this.models = models;
+        this.hook = hook({ models });
+      });
+  });
+
+  after(() => {
+    this.models.destroy();
+  });
+
+  describe('revocation', () => {
+
+    beforeEach(() => {
+      this.model = {
+        data: {
+          action: 'revoke',
+          model: 'project',
+          id: ids.model.project.revoke,
+          data: {},
+          changedBy: PELH_ID
+        },
+        setStatus: sinon.stub()
+      };
+    });
+
+    it('is sent to inspectorate if submitted by an establishment', () => {
+      return Promise.resolve()
+        .then(() => this.hook(this.model))
+        .then(() => {
+          assert.ok(this.model.setStatus.calledOnce);
+          assert.equal(this.model.setStatus.lastCall.args[0], withInspectorate.id);
+        });
+    });
+
+    it('resolves if submitted by a licensing officer', () => {
+      this.model.data.changedBy = LICENSING_ID;
+      return Promise.resolve()
+        .then(() => this.hook(this.model))
+        .then(() => {
+          assert.ok(this.model.setStatus.calledOnce);
+          assert.equal(this.model.setStatus.lastCall.args[0], resolved.id);
+        });
+    });
+
+    it('is sent to licensing if submitted by an inspector', () => {
+      this.model.data.changedBy = INSPECTOR_ID;
+      return Promise.resolve()
+        .then(() => this.hook(this.model))
+        .then(() => {
+          assert.ok(this.model.setStatus.calledOnce);
+          assert.equal(this.model.setStatus.lastCall.args[0], withLicensing.id);
+        });
+    });
+
+  });
+});


### PR DESCRIPTION
These should leave a visible record, so need to be resolved rather than autoresolved.