### PR TITLE
Optimise activity log data payloads

### DIFF
--- a/lib/middleware/profile.js
+++ b/lib/middleware/profile.js
@@ -2,12 +2,14 @@ module.exports = settings => {
   const { Profile } = settings.models;
   return (req, res, next) => {
 
+    delete req.user.access_token;
+
     if (req.user.profile) {
       return next();
     }
     return Profile.query()
       .findOne({ userId: req.user.id })
-      .eager('[roles, establishments, asru]')
+      .eager('[roles, establishments]')
       .then(profile => {
         if (profile && !profile.asruUser) {
           profile.asruLicensing = false;

--- a/lib/router/tasks.js
+++ b/lib/router/tasks.js
@@ -2,11 +2,26 @@ const { Router } = require('express');
 const router = Router({ mergeParams: true });
 const queryBuilder = require('../query-builders');
 
-module.exports = (taskflow) => {
+module.exports = (taskflow, settings) => {
 
   router.get('/', (req, res, next) => {
     const start = process.hrtime();
+    const { Profile } = settings.models;
+
     Promise.resolve()
+      .then(() => {
+        if (req.user.profile && req.user.profile.asruUser) {
+          return Profile.query()
+            .withGraphFetched('asru')
+            .modifyGraph('children', builder => {
+              builder.select('id');
+            })
+            .findOne({ id: req.user.profile.id })
+            .then(({ asru }) => {
+              req.user.profile.asru = asru;
+            });
+        }
+      })
       .then(() => {
         const profile = req.user.profile;
         const query = queryBuilder({ profile, ...req.query });

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -4,7 +4,7 @@ const { userAtMultipleEstablishments, ntco101, user, userWithActivePil } = requi
 
 module.exports = models => {
 
-  const { Establishment, Profile, PIL, Permission, Role } = models;
+  const { Establishment, Profile, PIL, Permission, Role, AsruEstablishment } = models;
 
   return Promise.resolve()
     .then(() => {
@@ -571,5 +571,12 @@ module.exports = models => {
             }
           ]);
         });
+    })
+    .then(() => {
+      // assign establishments to inspector and licensing user
+      return AsruEstablishment.query().insert([
+        { profileId: 'a942ffc7-e7ca-4d76-a001-0b5048a057d1', establishmentId: 101 },
+        { profileId: 'a942ffc7-e7ca-4d76-a001-0b5048a057d2', establishmentId: 101 }
+      ]);
     });
 };

--- a/test/data/profiles.js
+++ b/test/data/profiles.js
@@ -55,7 +55,6 @@ module.exports = {
     id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d1',
     establishments: [],
     roles: [],
-    asru: [{ id: 101 }],
     asruUser: true,
     asruInspector: true
   },
@@ -63,7 +62,6 @@ module.exports = {
     id: 'a942ffc7-e7ca-4d76-a001-0b5048a057d2',
     establishments: [],
     roles: [],
-    asru: [{ id: 101 }],
     asruUser: true,
     asruLicensing: true
   },

--- a/test/helpers/asl-db.js
+++ b/test/helpers/asl-db.js
@@ -6,6 +6,7 @@ module.exports = settings => {
     init: (populate, keepAlive) => {
       const schema = Schema(settings);
       const tables = [
+        'AsruEstablishment',
         'ProjectVersion',
         'Project',
         'Permission',


### PR DESCRIPTION
Don't eager load ASRU establishment assignments onto profiles by default. These are quite large objects, which use a lot of space on the profile and are saved on every activity, where tehy're onyl actualyl used for loading task lists.

Instead only load ASRU users establishment assignments when building a task list.

Also remove access token from the user, since it isn't used downstream and while it represents only a very mild security risk since it is short-lived, it has no business being saved to data.