### PR TITLE
Improve performance of task uniqueness check

### DIFF
--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -3,7 +3,7 @@ const match = require('minimatch');
 const { BadRequestError } = require('@asl/service/errors');
 
 const { Task } = require('@ukhomeoffice/taskflow');
-const { closed, editable } = require('../../flow');
+const { open, editable } = require('../../flow');
 const { resubmitted } = require('../../flow/status');
 
 module.exports = settings => {
@@ -32,7 +32,7 @@ module.exports = settings => {
 
     return Task.query()
       .whereJsonSupersetOf('data', { id })
-      .whereNotIn('status', closed())
+      .whereIn('status', open())
       .where('status', '!=', 'new')
       .then(results => {
         if (results && results.length) {

--- a/test/helpers/asl-db.js
+++ b/test/helpers/asl-db.js
@@ -6,6 +6,7 @@ module.exports = settings => {
     init: (populate, keepAlive) => {
       const schema = Schema(settings);
       const tables = [
+        'AsruEstablishment',
         'ProjectVersion',
         'Project',
         'Permission',


### PR DESCRIPTION
Use a `whereIn` instead of a `whereNotIn` for finding open tasks. This offers vastly improved performance because it facilitates the use of the index on task status.