### PR TITLE
Add hook to re-index search when entity changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,2 +1,5 @@
 extends:
   - lennym
+
+globals:
+  fetch: readonly

--- a/config.js
+++ b/config.js
@@ -39,5 +39,6 @@ module.exports = {
     secret: process.env.KEYCLOAK_SECRET,
     permissions: process.env.PERMISSIONS_SERVICE
   },
-  notifications: process.env.NOTIFICATIONS_SERVICE
+  notifications: process.env.NOTIFICATIONS_SERVICE,
+  search: process.env.SEARCH_SERVICE
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -34,6 +34,7 @@ const hooks = {
   validatePayload: require('./hooks/validate/payload'),
   autoForward: require('./hooks/auto-forward'),
   notify: require('./hooks/notify'),
+  search: require('./hooks/search'),
   editAndResubmit: require('./hooks/edit-and-resubmit'),
   submissionMeta: require('./hooks/submission-meta'),
   discard: require('./hooks/discard'),
@@ -100,6 +101,9 @@ module.exports = settings => {
 
   flow.hook(`status:*:${discardedByApplicant.id}`, hooks.discard(settings));
   flow.hook(`status:*:${discardedByAsru.id}`, hooks.discard(settings));
+
+  flow.hook(`status:*:${resolved.id}`, hooks.search(settings));
+  flow.hook(`status:*:${autoResolved.id}`, hooks.search(settings));
 
   app.use('/open-tasks', openTasksRouter(flow, settings));
   app.use('/related-tasks', relatedTasksRouter(flow, settings));

--- a/lib/hooks/search/index.js
+++ b/lib/hooks/search/index.js
@@ -1,0 +1,24 @@
+const { get } = require('lodash');
+
+module.exports = settings => event => {
+  if (settings.search) {
+    const allowed = ['establishment', 'profile', 'project'];
+    const model = get(event, 'data.model');
+
+    if (!allowed.includes(model)) {
+      return Promise.resolve();
+    }
+
+    const id = get(event, 'data.id');
+
+    // note the extra `s` on the model name
+    const url = `${settings.search}/${model}s/${id}`;
+    const headers = {
+      Authorization: `bearer ${event.meta.user.access_token}`
+    };
+
+    // don't wait for a response - the action should still complete if search indexing fails
+    fetch(url, { method: 'put', headers });
+  }
+  return Promise.resolve();
+};

--- a/lib/middleware/profile.js
+++ b/lib/middleware/profile.js
@@ -2,7 +2,13 @@ module.exports = settings => {
   const { Profile } = settings.models;
   return (req, res, next) => {
 
-    delete req.user.access_token;
+    // define access token as a non-enumerable property so it is accessible in code downstream
+    // but is not enumerated in activity logs event data
+    const token = req.user.access_token;
+    Object.defineProperty(req.user, 'access_token', {
+      enumerable: false,
+      value: token
+    });
 
     if (req.user.profile) {
       return next();


### PR DESCRIPTION
If a task relating to a profile, project or establishment completes then trigger a request to the search service to re-index the record.

Note: not waiting on any code changes, but probably doesn't need to ship until we have search working at least on preprod.