### PR TITLE
Refresh establishment search index when ASRU assignments change

### DIFF
--- a/lib/hooks/search/index.js
+++ b/lib/hooks/search/index.js
@@ -2,14 +2,18 @@ const { get } = require('lodash');
 
 module.exports = settings => event => {
   if (settings.search) {
-    const allowed = ['establishment', 'profile', 'project'];
-    const model = get(event, 'data.model');
-
+    const allowed = ['establishment', 'profile', 'project', 'asruEstablishment'];
+    let model = get(event, 'data.model');
     if (!allowed.includes(model)) {
       return Promise.resolve();
     }
 
-    const id = get(event, 'data.id');
+    let id = get(event, 'data.id');
+
+    if (model === 'asruEstablishment') {
+      model = 'establishment';
+      id = get(event, 'data.data.establishmentId');
+    }
 
     // note the extra `s` on the model name
     const url = `${settings.search}/${model}s/${id}`;


### PR DESCRIPTION
Otherwise the assignments shown in the search results will not be accurate until the next time the indexer runs.