### PR TITLE
Add remaining roles to task meta on role delete

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -37,6 +37,7 @@ const hooks = {
   search: require('./hooks/search'),
   editAndResubmit: require('./hooks/edit-and-resubmit'),
   submissionMeta: require('./hooks/submission-meta'),
+  resolutionMeta: require('./hooks/resolution-meta'),
   discard: require('./hooks/discard'),
   recall: require('./hooks/recall'),
   endorsed: require('./hooks/endorsed'),
@@ -104,6 +105,9 @@ module.exports = settings => {
 
   flow.hook(`status:*:${resolved.id}`, hooks.search(settings));
   flow.hook(`status:*:${autoResolved.id}`, hooks.search(settings));
+
+  flow.hook(`status:*:${resolved.id}`, hooks.resolutionMeta(settings));
+  flow.hook(`status:*:${autoResolved.id}`, hooks.resolutionMeta(settings));
 
   app.use('/open-tasks', openTasksRouter(flow, settings));
   app.use('/related-tasks', relatedTasksRouter(flow, settings));

--- a/lib/hooks/resolution-meta/index.js
+++ b/lib/hooks/resolution-meta/index.js
@@ -10,9 +10,9 @@ module.exports = settings => {
 
     if (type === 'role' && action === 'delete') {
       const id = get(model, 'data.id');
-      const establishmentId = get(model, 'data.establishmentId');
+      const establishmentId = get(model, 'data.modelData.establishmentId');
       const type = get(model, 'data.modelData.type');
-      const meta = get(model, 'data.meta');
+      const meta = get(model, 'data.meta', {});
 
       return Promise.resolve()
         .then(() => Role.query().where({ establishmentId, type }).whereNot({ id }).withGraphFetched('profile'))

--- a/lib/hooks/resolution-meta/index.js
+++ b/lib/hooks/resolution-meta/index.js
@@ -1,0 +1,33 @@
+const { get, pick } = require('lodash');
+
+// metadata applied at the resolution of a task
+module.exports = settings => {
+  const { Role } = settings.models;
+
+  return model => {
+    const type = get(model, 'data.model');
+    const action = get(model, 'data.action');
+
+    if (type === 'role' && action === 'delete') {
+      const id = get(model, 'data.id');
+      const establishmentId = get(model, 'data.establishmentId');
+      const type = get(model, 'data.modelData.type');
+      const meta = get(model, 'data.meta');
+
+      return Promise.resolve()
+        .then(() => Role.query().where({ establishmentId, type }).whereNot({ id }).withGraphFetched('profile'))
+        .then(roles => {
+          meta.remainingRoles = roles
+            .sort((a, b) => a.profile.lastName <= b.profile.lastName ? -1 : 1)
+            .map(r => ({
+              ...pick(r, ['id', 'type']),
+              profile: pick(r.profile, ['id', 'firstName', 'lastName'])
+            }));
+
+          return model.patch({ meta });
+        });
+    }
+
+    return Promise.resolve();
+  };
+};


### PR DESCRIPTION
We want to play back the remaining roles of the same type which were still assigned at the establishment at the moment the task was completed.