### PR TITLE
Send PPL amendments for endorsement

### DIFF
--- a/lib/decorators/deadline/get-deadline.js
+++ b/lib/decorators/deadline/get-deadline.js
@@ -3,7 +3,7 @@ const moment = require('moment-business-time');
 const { withInspectorate } = require('../../flow/status');
 
 // configure bank holidays
-moment.locale('en', { holidays: bankHolidays });
+moment.updateLocale('en', { holidays: bankHolidays });
 
 module.exports = task => {
   const lastSubmitted = task.activityLog.reduce((lastSubmission, activity) => {

--- a/lib/hooks/create/project.js
+++ b/lib/hooks/create/project.js
@@ -19,14 +19,8 @@ module.exports = settings => {
 
   const needsEndorsement = (model) => {
     const isEndorsed = get(model, 'data.meta.authority', '').toLowerCase() === 'yes';
-    const isTransfer = get(model, 'data.action') === 'transfer';
-    const isAmendment = get(model, 'data.modelData.status') === 'active';
     // don't require re-endorsing
     if (isEndorsed) {
-      return false;
-    }
-    // don't require endorsement on amendments
-    if (!isTransfer && isAmendment) {
       return false;
     }
     return true;

--- a/lib/hooks/create/project.js
+++ b/lib/hooks/create/project.js
@@ -19,6 +19,10 @@ module.exports = settings => {
 
   const needsEndorsement = (model) => {
     const isEndorsed = get(model, 'data.meta.authority', '').toLowerCase() === 'yes';
+    const isASRU = get(model, 'meta.user.profile.asruUser');
+    if (isASRU) {
+      return false;
+    }
     // don't require re-endorsing
     if (isEndorsed) {
       return false;

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -355,7 +355,7 @@ module.exports = models => {
                 licenceNumber: '70/1235',
                 version: [
                   {
-                    id: ids.model.projectVersion.continution,
+                    id: ids.model.projectVersion.continuation,
                     status: 'draft',
                     data: {
                       'transfer-expiring': true,

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -69,7 +69,7 @@ module.exports = {
     },
     projectVersion: {
       recalledTransfer: uuid(),
-      continution: uuid(),
+      continuation: uuid(),
       continuation2: uuid(),
       notAContinuation: uuid(),
       transfer: uuid(),

--- a/test/integration/project/continuation.js
+++ b/test/integration/project/continuation.js
@@ -30,7 +30,7 @@ describe('Project continuation', () => {
       establishmentId: 100,
       id: ids.model.project.continuation,
       data: {
-        version: ids.model.projectVersion.continution
+        version: ids.model.projectVersion.continuation
       }
     };
     const expected = [

--- a/test/unit/hooks/create/project.js
+++ b/test/unit/hooks/create/project.js
@@ -155,6 +155,41 @@ describe('Project create hook', () => {
         });
     });
 
+    it('does not require endorsement if it is an amendment submitted by a licensing officer', () => {
+      const model = {
+        data: {
+          action: 'grant',
+          model: 'project',
+          id: ids.model.project.grant,
+          data: {
+            version: ids.model.projectVersion.grant,
+            modelData: {
+              status: 'active'
+            }
+          },
+          establishmentId: 100,
+          changedBy: LICENSING_ID
+        },
+        meta: {
+          user: {
+            profile: {
+              id: LICENSING_ID,
+              asruUser: true,
+              asruLicensing: true
+            }
+          }
+        },
+        setStatus: sinon.stub()
+      };
+
+      return Promise.resolve()
+        .then(() => this.hook(model))
+        .then(() => {
+          assert.ok(model.setStatus.calledOnce);
+          assert.equal(model.setStatus.lastCall.args[0], withInspectorate.id);
+        });
+    });
+
     it('does not require endorsement if submitted by an admin user', () => {
       const model = {
         data: {

--- a/test/unit/hooks/create/project.js
+++ b/test/unit/hooks/create/project.js
@@ -90,7 +90,46 @@ describe('Project create hook', () => {
           model: 'project',
           id: ids.model.project.grant,
           data: {
-            version: ids.model.projectVersion.grant
+            version: ids.model.projectVersion.grant,
+            modelData: {
+              status: 'inactive'
+            }
+          },
+          establishmentId: 100,
+          changedBy: BASIC_USER
+        },
+        meta: {
+          user: {
+            profile: {
+              id: BASIC_USER,
+              establishments: [
+                { id: 100, role: 'basic' }
+              ]
+            }
+          }
+        },
+        setStatus: sinon.stub()
+      };
+
+      return Promise.resolve()
+        .then(() => this.hook(model))
+        .then(() => {
+          assert.ok(model.setStatus.calledOnce);
+          assert.equal(model.setStatus.lastCall.args[0], awaitingEndorsement.id);
+        });
+    });
+
+    it('requires endorsement if it is an amendment submitted by a basic user', () => {
+      const model = {
+        data: {
+          action: 'grant',
+          model: 'project',
+          id: ids.model.project.grant,
+          data: {
+            version: ids.model.projectVersion.grant,
+            modelData: {
+              status: 'active'
+            }
           },
           establishmentId: 100,
           changedBy: BASIC_USER
@@ -123,7 +162,10 @@ describe('Project create hook', () => {
           model: 'project',
           id: ids.model.project.grant,
           data: {
-            version: ids.model.projectVersion.grant
+            version: ids.model.projectVersion.grant,
+            modelData: {
+              status: 'inactive'
+            }
           },
           establishmentId: 100,
           changedBy: BASIC_USER
@@ -156,7 +198,10 @@ describe('Project create hook', () => {
           model: 'project',
           id: ids.model.project.grant,
           data: {
-            version: ids.model.projectVersion.grant
+            version: ids.model.projectVersion.grant,
+            modelData: {
+              status: 'inactive'
+            }
           },
           meta: {
             authority: 'yes'

--- a/test/unit/hooks/create/project.js
+++ b/test/unit/hooks/create/project.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const { withLicensing, withInspectorate, resolved } = require('../../../../lib/flow/status');
-const hook = require('../../../../lib/hooks/create/role');
+const statuses = require('../../../../lib/flow/status');
+const hook = require('../../../../lib/hooks/create/project');
 const Database = require('../../../helpers/asl-db');
 const fixtures = require('../../../data');
 const ids = require('../../../data/ids');
@@ -11,13 +11,23 @@ const settings = require('../../../helpers/database-settings');
 const INSPECTOR_ID = 'a942ffc7-e7ca-4d76-a001-0b5048a057d1';
 const LICENSING_ID = 'a942ffc7-e7ca-4d76-a001-0b5048a057d2';
 const PELH_ID = 'ae28fb31-d867-4371-9b4f-79019e71232f';
+const BASIC_USER = 'ae28fb31-d867-4371-9b4f-79019e71232f';
+
+const {
+  awaitingEndorsement,
+  endorsed,
+  withLicensing,
+  withInspectorate,
+  resolved
+} = statuses;
 
 describe('Project create hook', () => {
   before(() => {
+    const StubMessager = sinon.stub().resolves({});
     return Database(settings.db).init(fixtures.default, true)
       .then(models => {
         this.models = models;
-        this.hook = hook({ models });
+        this.hook = hook({ models, StubMessager });
       });
   });
 
@@ -70,4 +80,111 @@ describe('Project create hook', () => {
     });
 
   });
+
+  describe('grant', () => {
+
+    it('requires endorsement if submitted by a basic user', () => {
+      const model = {
+        data: {
+          action: 'grant',
+          model: 'project',
+          id: ids.model.project.grant,
+          data: {
+            version: ids.model.projectVersion.grant
+          },
+          establishmentId: 100,
+          changedBy: BASIC_USER
+        },
+        meta: {
+          user: {
+            profile: {
+              id: BASIC_USER,
+              establishments: [
+                { id: 100, role: 'basic' }
+              ]
+            }
+          }
+        },
+        setStatus: sinon.stub()
+      };
+
+      return Promise.resolve()
+        .then(() => this.hook(model))
+        .then(() => {
+          assert.ok(model.setStatus.calledOnce);
+          assert.equal(model.setStatus.lastCall.args[0], awaitingEndorsement.id);
+        });
+    });
+
+    it('does not require endorsement if submitted by an admin user', () => {
+      const model = {
+        data: {
+          action: 'grant',
+          model: 'project',
+          id: ids.model.project.grant,
+          data: {
+            version: ids.model.projectVersion.grant
+          },
+          establishmentId: 100,
+          changedBy: BASIC_USER
+        },
+        meta: {
+          user: {
+            profile: {
+              id: BASIC_USER,
+              establishments: [
+                { id: 100, role: 'admin' }
+              ]
+            }
+          }
+        },
+        setStatus: sinon.stub()
+      };
+
+      return Promise.resolve()
+        .then(() => this.hook(model))
+        .then(() => {
+          assert.ok(model.setStatus.calledOnce);
+          assert.equal(model.setStatus.lastCall.args[0], endorsed.id);
+        });
+    });
+
+    it('does not require endorsement if re-submitted by a basic user having been endorsed previously', () => {
+      const model = {
+        data: {
+          action: 'grant',
+          model: 'project',
+          id: ids.model.project.grant,
+          data: {
+            version: ids.model.projectVersion.grant
+          },
+          meta: {
+            authority: 'yes'
+          },
+          establishmentId: 100,
+          changedBy: BASIC_USER
+        },
+        meta: {
+          user: {
+            profile: {
+              id: BASIC_USER,
+              establishments: [
+                { id: 100, role: 'basic' }
+              ]
+            }
+          }
+        },
+        setStatus: sinon.stub()
+      };
+
+      return Promise.resolve()
+        .then(() => this.hook(model))
+        .then(() => {
+          assert.ok(model.setStatus.calledOnce);
+          assert.equal(model.setStatus.lastCall.args[0], withInspectorate.id);
+        });
+    });
+
+  });
+
 });


### PR DESCRIPTION
Instead of skipping the endorsement step for PPL amendments send all PPL grant tasks to admins for endorsement unless they're initiated by ASRU users.

