### PR TITLE
Prevent adding empty exemption if none exist

### DIFF
--- a/lib/decorators/normalise-training.js
+++ b/lib/decorators/normalise-training.js
@@ -8,6 +8,10 @@ function uniqConcat(a, b) {
 }
 
 function normaliseExemptions(exemptions) {
+  if (!exemptions || !exemptions.length) {
+    return;
+  }
+
   return exemptions.reduce((cert, exemption) => {
     const exemptionReason = cert.exemptionReason || '';
     return {
@@ -42,12 +46,16 @@ function normaliseTraining(data) {
     return certificates;
   }
 
-  const exemptionCert = normaliseExemptions(data.exemptions || []);
+  const exemptionCert = normaliseExemptions(data.exemptions);
 
-  return [
-    ...certificates,
-    exemptionCert
-  ];
+  if (exemptionCert) {
+    return [
+      ...certificates,
+      exemptionCert
+    ];
+  }
+
+  return certificates;
 }
 
 module.exports = settings => task => {

--- a/test/unit/decorators/normalise-training.js
+++ b/test/unit/decorators/normalise-training.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const decorator = require('../../../lib/decorators/normalise-training');
+
+describe('normalise-training decorator', () => {
+
+  it('does not add an exemption if none exist', () => {
+    const input = {
+      data: {
+        certificates: [],
+        exemptions: []
+      }
+    };
+    const decorate = decorator({});
+    assert.deepEqual(decorate(input).data.certificates, []);
+  });
+
+});


### PR DESCRIPTION
Adding the result of a reduce on an empty array meant that the certificates were always appended with `{}` if no exemptions are present.

Return early if there are no exemptions and don't add a record to the certificates.