### PR TITLE
Update search index on profile merges and PIL grants

### DIFF
--- a/lib/hooks/search/index.js
+++ b/lib/hooks/search/index.js
@@ -2,13 +2,20 @@ const { get } = require('lodash');
 
 module.exports = settings => event => {
   if (settings.search) {
-    const allowed = ['establishment', 'profile', 'project', 'asruEstablishment'];
+    const allowed = ['establishment', 'profile', 'project', 'asruEstablishment', 'pil'];
+
     let model = get(event, 'data.model');
+    let id = get(event, 'data.id');
+    const action = get(event, 'data.action');
+
     if (!allowed.includes(model)) {
       return Promise.resolve();
     }
 
-    let id = get(event, 'data.id');
+    if (model === 'pil') {
+      model = 'profile';
+      id = get(event, 'data.data.profileId');
+    }
 
     if (model === 'asruEstablishment') {
       model = 'establishment';
@@ -23,6 +30,12 @@ module.exports = settings => event => {
 
     // don't wait for a response - the action should still complete if search indexing fails
     fetch(url, { method: 'put', headers });
+
+    // send a second request to the other profile when merging profiles
+    if (model === 'profile' && action === 'merge') {
+      id = get(event, 'data.data.target');
+      fetch(`${settings.search}/${model}s/${id}`, { method: 'put', headers });
+    }
   }
   return Promise.resolve();
 };


### PR DESCRIPTION
Both of these will change the search index in ways which are not currently refreshed. Ensure that the search index stays up to date for both profiles in a merger, and adds the new licence number when granting a PIL.