### PR TITLE
Preserve establishment id when resubmitting PPL tasks

### DIFF
--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -54,7 +54,14 @@ module.exports = settings => {
               .then(task => {
                 return Promise.resolve()
                   // update the existing task with new data
-                  .then(() => task.patch({ data }, model.meta))
+                  .then(() => {
+                    if (type === 'project' && conflictAction === 'grant') {
+                      // preserve establishment id on project tasks
+                      const establishmentId = get(task.toJSON(), 'data.data.establishmentId');
+                      data.establishmentId = establishmentId;
+                    }
+                    return task.patch({ data }, model.meta);
+                  })
                   // mark existing task as resubmitted
                   .then(() => task.status(resubmitted.id, model.meta));
               })

--- a/test/integration/hooks/unique.js
+++ b/test/integration/hooks/unique.js
@@ -87,6 +87,7 @@ describe('unique hook', () => {
       .expect(200)
       .expect(response => {
         assert.equal(response.body.data.id, ids.task.project.recalledTransfer);
+        assert.equal(response.body.data.data.establishmentId, 101, 'the establishment id on the task should be left intact');
       });
   });
 


### PR DESCRIPTION
The `establishmentId` property was being reset to the originating establishment when resubmitting PPL transfers, which when eventually resolved resulted in broken PPL states.

When patching the data on a task resubmission do not overwrite the establishment id.