### PR TITLE
Store deadlinePassedDate as a separate property on the task so it doesn't get removed

### DIFF
--- a/bin/deadline-has-passed
+++ b/bin/deadline-has-passed
@@ -44,7 +44,7 @@ const migrate = async () => {
     for (const task of tasks) {
       console.log(`${task.id}: marking as deadline passed`);
       await task.$query(transaction)
-        .patchAndFetch({ data: { ...task.data, deadlinePassed: true } })
+        .patchAndFetch({ data: { ...task.data, deadlinePassed: true, deadlinePassedDate: task.deadlineDate } })
         .context({ preserveUpdatedAt: true });
     }
 

--- a/lib/router/deadline-passed.js
+++ b/lib/router/deadline-passed.js
@@ -80,7 +80,6 @@ module.exports = taskflow => {
       const reasoning = getReasoning(task);
       return {
         ...omit(task, 'activityLog'),
-        daysOverdue: moment().diff(task.deadlineDate, 'days'),
         reason: !isEmpty(reasoning.reason) ? reasoning.reason : null,
         isExempt: reasoning.exemption.isExempt,
         exemption: reasoning.exemption

--- a/lib/router/deadline-passed.js
+++ b/lib/router/deadline-passed.js
@@ -1,6 +1,6 @@
 const { Router } = require('express');
 const { get, omit, isEmpty } = require('lodash');
-const { raw, ref } = require('objection');
+const { ref } = require('objection');
 const router = Router({ mergeParams: true });
 const moment = require('moment-business-time');
 const { bankHolidays } = require('@asl/constants');
@@ -16,12 +16,7 @@ module.exports = taskflow => {
     let query = Task.query()
       .select(
         'cases.*',
-        raw(`
-          CASE
-            WHEN (data->'deadline'->>'isExtended')::boolean = true
-            THEN data->'deadline'->>'extended'
-            ELSE data->'deadline'->>'standard'
-          END AS deadline_date`),
+        ref('data:deadlinePassedDate').castText().as('deadlinePassedDate'),
         ref('data:modelData.title').castText().as('projectTitle')
       )
       .where(ref('data:deadlinePassed').castBool(), true)


### PR DESCRIPTION
We need the deadline at the time the deadline was passed, as the deadline object may disappear if the task is returned to the applicant.