### PR TITLE
Make sure we don't touch any existing deadline objects

### DIFF
--- a/bin/add-deadlines-to-legacy-tasks
+++ b/bin/add-deadlines-to-legacy-tasks
@@ -69,11 +69,7 @@ const migrate = async () => {
       .select('id')
       .whereIn('status', withAsruOrComplete)
       .whereJsonSupersetOf('data', { model: 'project', action: 'grant' })
-      .where(builder => {
-        // will match deadline: null, missing deadline key, and missing deadline->standard key
-        builder.whereRaw("data->>'deadline' is null")
-          .orWhereRaw("data->'deadline'->>'standard' is null");
-      });
+      .whereRaw("data->>'deadline' is null"); // will match deadline: null, missing deadline key
 
     stats.found = tasks.length;
 


### PR DESCRIPTION
The `.orWhereRaw("data->'deadline'->>'standard' is null")` condition was added to "fix" the tasks on preprod that were left without dates the first time we ran the script.

This is no-longer the case so let's get rid of this extra condition and make doubly sure we don't overwrite any existing deadline objects.