### PR TITLE
Seed was prev set up to test deadline scripts

### DIFF
--- a/seeds/data/cases.json
+++ b/seeds/data/cases.json
@@ -148,6 +148,8 @@
         "isExtended": false,
         "isExtendable": true
       },
+      "deadlinePassed": true,
+      "deadlinePassedDate": "2020-07-27",
       "extended": null,
       "changedBy": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd",
       "modelData": {


### PR DESCRIPTION
This seed should now include the flags added by the deadline migration scripts which were previously left out to test the scripts.