### PR TITLE
Fix "before" state for completed PPL holder changes

### DIFF
--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -80,6 +80,15 @@ module.exports = settings => {
           ...task,
           activityLog
         };
+      })
+      .then(async task => {
+        // some closed ppl licence holder tasks don't show the _before_ state correctly because modelData
+        // was not fully populated at the time of submission.
+        const modelData = get(task, 'activityLog[0].event.data.modelData', {});
+        if (!task.isOpen && modelData.licenceHolderId && !modelData.licenceHolder) {
+          modelData.licenceHolder = await cache.query(Profile, modelData.licenceHolderId);
+        }
+        return task;
       });
 
   };

--- a/lib/decorators/licence-holder.js
+++ b/lib/decorators/licence-holder.js
@@ -5,18 +5,19 @@ module.exports = settings => {
   const { Profile } = settings.models;
   const cache = Cacheable();
 
-  return c => {
-    const licenceHolderId = get(c, 'data.data.licenceHolderId');
+  return task => {
+    let licenceHolderId = get(task, 'data.data.licenceHolderId');
+
     if (!licenceHolderId) {
-      return c;
+      return task;
     }
 
     return cache.query(Profile, licenceHolderId)
       .then(licenceHolder => {
         return {
-          ...c,
+          ...task,
           data: {
-            ...c.data,
+            ...task.data,
             licenceHolder
           }
         };

--- a/lib/hooks/model-data/index.js
+++ b/lib/hooks/model-data/index.js
@@ -4,7 +4,7 @@ module.exports = settings => {
   const { Place, Establishment, Project, PIL, Profile, Role } = settings.models;
 
   function constrainProfileParams(builder) {
-    return builder.select('firstName', 'lastName', 'id');
+    return builder.select('firstName', 'lastName', 'id', 'email');
   }
 
   function constrainProjectParams(builder) {


### PR DESCRIPTION
When a task to change PPL holder is closed the "before" state for the licence holder disappears if the task was created before the change to populate `modelData` shipped.

In this case add a decorator to populate the `modelData.licenceHolder` on the submission activity.

Additionally add the email to the `modelData` population hook because this is normally rendered but looks a bit odd when it disappears on completion.