### PR TITLE
Serve activity log on autoresolved tasks

### DIFF
--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -1,6 +1,5 @@
 const { get } = require('lodash');
 const Cacheable = require('./cacheable');
-const { autoResolved } = require('../flow/status');
 
 function getItemStatus(item) {
   return item && item.eventName.split(':').pop();
@@ -29,12 +28,6 @@ module.exports = settings => {
   return task => {
     if (!task.activityLog) {
       return task;
-    }
-    if (task.status === autoResolved.id) {
-      return {
-        ...task,
-        activityLog: null
-      };
     }
 
     const promises = task.activityLog.map(log => cache.query(Profile, log.changedBy));


### PR DESCRIPTION
Rendering a task fails if there is no associated activity. Sometimes we need to be able to render autoresolved tasks, so allow them to serve their activity log if requested.