### PR TITLE
Re-index search when submitting tasks

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -109,6 +109,7 @@ module.exports = settings => {
   flow.hook(`status:*:${discardedByApplicant.id}`, hooks.discard(settings));
   flow.hook(`status:*:${discardedByAsru.id}`, hooks.discard(settings));
 
+  flow.hook(`status:*:${withInspectorate.id}`, hooks.search(settings));
   flow.hook(`status:*:${resolved.id}`, hooks.search(settings));
   flow.hook(`status:*:${autoResolved.id}`, hooks.search(settings));
 


### PR DESCRIPTION
This allows PPL applications to appear in search once they are submitted to ASRU