### PR TITLE
Don't enforce uniqueness of tasks for email verification actions

### DIFF
--- a/lib/hooks/create/unique.js
+++ b/lib/hooks/create/unique.js
@@ -19,7 +19,9 @@ module.exports = settings => {
       'feeWaiver.*',
       'project.fork',
       'establishment.update-conditions',
-      'establishment.update-billing'
+      'establishment.update-billing',
+      'profile.resend-email',
+      'profile.confirm-email'
     ];
 
     if (nopes.some(str => match(`${type}.${action}`, str))) {


### PR DESCRIPTION
If there is an open profile amendment task and the user verifies their email (or more likely logs in with email already verified in keycloak and so auto-verifies) then don't block the task.