### PR TITLE
Don't attempt to re-index objects with undefined id

### DIFF
--- a/lib/hooks/search/index.js
+++ b/lib/hooks/search/index.js
@@ -22,6 +22,10 @@ module.exports = settings => event => {
       id = get(event, 'data.data.establishmentId');
     }
 
+    if (!id) {
+      return Promise.resolve();
+    }
+
     // note the extra `s` on the model name
     const url = `${settings.search}/${model}s/${id}`;
     const headers = {


### PR DESCRIPTION
The search re-index hook is set up to fire on task submission to ASRU (to handle draft PPL submissions) however entity creation tasks don't have an id at this point and result in an error in the search indexer.

Ignore anything that doesn't have an id and don't try to index it.