### PR TITLE
Update search index on perms change

### DIFF
--- a/lib/hooks/search/index.js
+++ b/lib/hooks/search/index.js
@@ -2,7 +2,7 @@ const { get } = require('lodash');
 
 module.exports = settings => event => {
   if (settings.search) {
-    const allowed = ['establishment', 'profile', 'project', 'asruEstablishment', 'place', 'pil'];
+    const allowed = ['establishment', 'profile', 'project', 'asruEstablishment', 'place', 'pil', 'permission'];
 
     let model = get(event, 'data.model');
     let id = get(event, 'data.id');
@@ -12,7 +12,7 @@ module.exports = settings => event => {
       return Promise.resolve();
     }
 
-    if (model === 'pil' || model === 'trainingPil') {
+    if (model === 'pil' || model === 'trainingPil' || model === 'permission') {
       model = 'profile';
       id = get(event, 'data.data.profileId');
     }


### PR DESCRIPTION
The profile search was showing establishment associations after they were removed. Trigger a profile re-index when associated perms are changed.