### PR TITLE
Don't log errors for 4xx range

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -124,7 +124,9 @@ module.exports = settings => {
 
   app.use((err, req, res, json) => {
     err.status = err.status || 500;
-    req.log('error', { ...err, message: err.message, stack: err.stack, status: err.status });
+    if (err.status > 499) {
+      req.log('error', { ...err, message: err.message, stack: err.stack, status: err.status });
+    }
     res.status(err.status);
     res.json({
       message: err.message,


### PR DESCRIPTION
There's _a lot_ of 403s for related tasks which we don't really care about in the logs. The basic logging is fine for 4xx range errors.