### PR TITLE
Fix RA submission by ASRU users

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -12,6 +12,15 @@ steps:
         from_secret: npm_auth_token
     commands:
       - npm ci
+  - name: wait
+    image: postgres
+    environment:
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: test-password
+    commands:
+      # wait for postgres service to become available
+      - until psql -c "SELECT 1;" >/dev/null 2>&1; do sleep 1; done
   - name: database setup
     image: postgres
     environment:

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,18 +3,28 @@ const { diff } = require('deep-diff');
 
 function canEndorse(task) {
   const type = get(task, 'data.model');
+  const action = get(task, 'data.action');
   const profile = get(task, 'meta.user.profile');
   const establishmentId = get(task, 'data.establishmentId');
+
+  if (profile.asruUser && action === 'grant-ra') {
+    return true;
+  }
 
   switch (type) {
     case 'pil':
     case 'trainingPil':
       return !!profile.roles.find(role => role.establishmentId === establishmentId && role.type === 'ntco');
     case 'project':
-      return profile.establishments.find(e => e.id === establishmentId).role === 'admin';
+      return isAdminAtEstablishment(profile, establishmentId);
     default:
       return false;
   }
+}
+
+function isAdminAtEstablishment(profile, establishmentId) {
+  const permission = profile.establishments.find(e => e.id === establishmentId);
+  return permission && permission.role === 'admin';
 }
 
 function getEstablishmentsWhereUserIsRole(role, profile) {

--- a/test/unit/hooks/create/project.js
+++ b/test/unit/hooks/create/project.js
@@ -141,6 +141,36 @@ describe('Project create hook', () => {
           assert.equal(model.setStatus.lastCall.args[0], endorsed.id);
         });
     });
+
+    it('doesn\'t require endorsement if submitted by an ASRU user', () => {
+      const model = {
+        data: {
+          action: 'grant-ra',
+          model: 'project',
+          id: ids.model.project.grant,
+          establishmentId: 100,
+          changedBy: LICENSING_ID
+        },
+        meta: {
+          user: {
+            profile: {
+              id: LICENSING_ID,
+              asruUser: true,
+              asruLicensing: true,
+              establishments: []
+            }
+          }
+        },
+        setStatus: sinon.stub()
+      };
+
+      return Promise.resolve()
+        .then(() => this.hook(model))
+        .then(() => {
+          assert.ok(model.setStatus.calledOnce);
+          assert.equal(model.setStatus.lastCall.args[0], endorsed.id);
+        });
+    });
   });
 
   describe('grant', () => {


### PR DESCRIPTION
The `canEndorse` function was throwing an error because it did not expect to be called with an ASRU user's profile - and therefore have no establishments.