### PR TITLE
PIL applications have modelData.status pending not inactive

### DIFF
--- a/lib/query-builders/filters/by-is-amendment.js
+++ b/lib/query-builders/filters/by-is-amendment.js
@@ -6,6 +6,7 @@ module.exports = isAmendment => query => {
 
   return query.where(builder => {
     builder.whereJsonSupersetOf('data', { modelData: { status: 'inactive' } });
+    builder.orWhereJsonSupersetOf('data', { modelData: { status: 'pending' } });
     builder.orWhereRaw(`data->'modelData'->>'status' IS NULL`);
   });
 };


### PR DESCRIPTION
This was stopping anything other than trainingPils displaying in the metrics taskslists.