### PR TITLE
Just use not already active for applications

### DIFF
--- a/lib/query-builders/filters/by-is-amendment.js
+++ b/lib/query-builders/filters/by-is-amendment.js
@@ -5,8 +5,7 @@ module.exports = isAmendment => query => {
   }
 
   return query.where(builder => {
-    builder.whereJsonSupersetOf('data', { modelData: { status: 'inactive' } });
-    builder.orWhereJsonSupersetOf('data', { modelData: { status: 'pending' } });
+    builder.whereRaw(`data->'modelData'->>'status' != 'active'`);
     builder.orWhereRaw(`data->'modelData'->>'status' IS NULL`);
   });
 };


### PR DESCRIPTION
Some of the PIL applications counted on the summary page are re-activations of revoked PILs (modelData.status = 'revoked') but we were excluding these from the tasklist.
