### PR TITLE
Exclude autoresolved project tasks from related tasks

### DIFF
--- a/lib/router/related-tasks.js
+++ b/lib/router/related-tasks.js
@@ -41,11 +41,14 @@ module.exports = taskflow => {
 
       case 'project':
         query
-          .whereJsonSupersetOf('data', { id: modelId })
-          .orWhere(builder => {
+          .where(builder => {
             builder
-              .whereJsonSupersetOf('data', { model: 'rop' })
-              .whereJsonSupersetOf('data:data', { projectId: modelId });
+              .whereJsonSupersetOf('data', { id: modelId })
+              .orWhere(builder => {
+                builder
+                  .whereJsonSupersetOf('data', { model: 'rop' })
+                  .whereJsonSupersetOf('data:data', { projectId: modelId });
+              });
           });
 
         break;

--- a/test/data/tasks.js
+++ b/test/data/tasks.js
@@ -680,6 +680,25 @@ const tasks = [
   {
     id: uuid(),
     data: {
+      id: ids.model.project.holc,
+      data: {
+        name: 'holc owned project autoresolved'
+      },
+      initiatedByAsru: false,
+      establishmentId: 100,
+      changedBy: holc.id,
+      subject: holc.id,
+      model: 'project',
+      modelData: {
+        licenceHolderId: holc.id
+      }
+    },
+    status: 'autoresolved',
+    ...generateDates(31)
+  },
+  {
+    id: uuid(),
+    data: {
       id: 100,
       data: {
         name: 'granted establishment update'


### PR DESCRIPTION
The project related tasks query started an "or" query context, which meant that the status filters were included in the "or" instead of the "and" that they were expected to be in.

Instead create a new context for the "or" clauses to contain those.