### PR TITLE
Tweak - dont include null assignedTo

### DIFF
--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -68,7 +68,7 @@ module.exports = settings => {
 
         activityLog = activityLog.map(log => {
           log.changedBy = logChangedBys.find(profile => profile && profile.id === log.changedBy) || {};
-          log.assignedTo = logAssignedTos.find(profile => profile && profile.id === log.event.meta.assignedTo) || {};
+          log.assignedTo = logAssignedTos.find(profile => profile && profile.id === log.event.meta.assignedTo);
           delete log.event.meta.user.access_token;
           return log;
           // sort by createdAt descending


### PR DESCRIPTION
* If decorator doesn't find a profile for assigned to, dont default to empty object