### PR TITLE
Discard tasks related to expired PPLs

### DIFF
--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash');
+const { get, set } = require('lodash');
 const Cacheable = require('./cacheable');
 
 function getItemStatus(item) {
@@ -69,7 +69,7 @@ module.exports = settings => {
         activityLog = activityLog.map(log => {
           log.changedBy = logChangedBys.find(profile => profile && profile.id === log.changedBy) || {};
           log.assignedTo = logAssignedTos.find(profile => profile && profile.id === log.event.meta.assignedTo);
-          delete log.event.meta.user.access_token;
+          set(log, 'event.meta.user.access_token', undefined);
           return log;
           // sort by createdAt descending
         }).sort((a, b) => b.createdAt > a.createdAt ? 1 : -1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3450,9 +3450,9 @@
       }
     },
     "@ukhomeoffice/taskflow": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/taskflow/-/taskflow-2.4.1.tgz",
-      "integrity": "sha512-m2t1J7WJWVTl2fxa7iKwo0IqYpdai9NpyDqpPgmuNWyNJtzMCF7mMjDV7ov30+CpBk71fFTtpkbuNacCZYJ1zQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/taskflow/-/taskflow-2.4.2.tgz",
+      "integrity": "sha512-gCQvQihb7bkzML8TKPJHaQR+qLv3YrB1zx+5Rvo9dSihHNrQGyxS6rb3FHmjqgH/6yEh74X42tVgLynT8ynGxg==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@asl/constants": "^0.8.1",
     "@asl/schema": "^9.15.3",
     "@asl/service": "^8.8.4",
-    "@ukhomeoffice/taskflow": "^2.4.1",
+    "@ukhomeoffice/taskflow": "^2.4.2",
     "aws-sdk": "^2.270.1",
     "deep-diff": "^1.0.2",
     "express": "^4.16.4",

--- a/scripts/discard-expired-projects.js
+++ b/scripts/discard-expired-projects.js
@@ -1,0 +1,44 @@
+try {
+  require('dotenv/config');
+} catch(e) {
+  // ignore
+}
+
+const Taskflow = require('@ukhomeoffice/taskflow');
+const schema = require('@asl/schema');
+const { transaction } = require('objection');
+const settings = require('../config');
+const { open } = require('../lib/flow');
+
+const discard = async () => {
+  const { Project } = schema(settings.db);
+  const { Task, db } = Taskflow({ db: settings.taskflowDB });
+  const trx = await transaction.start(db);
+  try {
+    const tasks = await Task.query(trx)
+      .whereIn('status', open())
+      .whereJsonSupersetOf('data', { model: 'project', action: 'grant' });
+
+    for await (const task of tasks) {
+      const project = await Project.query().findById(task.data.id);
+      console.log(project.status);
+      if (project.status === 'expired') {
+        console.log(`Discarding task ${task.id}`);
+        const model = await Task.find(task.id, trx);
+        await model.status('discarded-by-asru', { payload: { meta: { comment: 'Automatically discarded when project licence expired.' } } });
+      }
+    }
+    await trx.commit();
+  } catch (e) {
+    await trx.rollback();
+    throw e;
+  }
+};
+
+Promise.resolve()
+  .then(() => discard())
+  .then(() => process.exit())
+  .catch(err => {
+    console.error(err.stack);
+    process.exit(1);
+  });


### PR DESCRIPTION
Once a PPL has expired then amendments and transfers that might be in progress should be discarded.

This adds a script which will run as a nightly cron to do that.