### PR TITLE
Allow fetching of tasks owned by the profile

### DIFF
--- a/lib/router/related-tasks.js
+++ b/lib/router/related-tasks.js
@@ -27,7 +27,8 @@ module.exports = taskflow => {
         break;
 
       case 'profile-touched':
-        // any tasks that have involved the profile (e.g. licence holder, application submitter, profile update, role assignment)
+        // all tasks that have involved the profile
+        // e.g. licence holder, application submitter, application endorsement, profile updates, role assignment
         query.where(builder => {
           builder
             .whereJsonSupersetOf('data', { subject: modelId })
@@ -36,6 +37,15 @@ module.exports = taskflow => {
             .orWhereExists(
               Task.relatedQuery('activityLog').where('changedBy', modelId)
             );
+        });
+        break;
+
+      case 'profile-owned':
+        // any tasks involving licences owned by the profile, profile updates or role assignment
+        query.where(builder => {
+          builder
+            .whereJsonSupersetOf('data', { subject: modelId })
+            .orWhereJsonSupersetOf('data', { id: modelId });
         });
         break;
 
@@ -120,7 +130,7 @@ module.exports = taskflow => {
 
   const checkPermissions = (user, query) => {
     let { model, modelId } = query;
-    model = model === 'profile-touched' ? 'profile' : model;
+    model = ['profile-touched', 'profile-owned'].includes(model) ? 'profile' : model;
 
     const params = {
       id: modelId,


### PR DESCRIPTION
When checking if a user can be removed from an establishment, we don't care about tasks that the user has endorsed (or some other interaction) if they are not the owner of the licence itself.