### PR TITLE
Prevent task status label getting overwritten by assign

### DIFF
--- a/lib/decorators/activity-log.js
+++ b/lib/decorators/activity-log.js
@@ -52,7 +52,9 @@ module.exports = settings => {
             ((item.event.req && item.event.req === prev.event.req) || isTransientChange);
 
           if (shouldSquash) {
-            store[store.length - 1].status = itemStatus;
+            if (itemStatus !== 'assign') {
+              store[store.length - 1].status = itemStatus;
+            }
             return store;
           } else {
             return [


### PR DESCRIPTION
If an auto-unassignment is triggered by an assigned task changing status, then the status of the previous activity log item was being overwritten with "assign" which caused the task status in the task view to always display "Task Assigned" whenever this happened (including on task resolution).