### PR TITLE
Filter out RA tasks from PPL application filters

### DIFF
--- a/lib/query-builders/filters/by-ppl-type.js
+++ b/lib/query-builders/filters/by-ppl-type.js
@@ -4,10 +4,17 @@ const filterByAction = require('./by-action');
 module.exports = pplType => query => {
   switch (pplType) {
     case 'applications':
-      return query.andWhere(filterByIsAmendment(false));
+      return query
+        .andWhere(filterByAction('grant'))
+        .andWhere(filterByIsAmendment(false));
 
     case 'amendments':
-      return query.andWhere(filterByIsAmendment(true));
+      return query
+        .andWhere(filterByAction('grant'))
+        .andWhere(filterByIsAmendment(true));
+
+    case 'revocations':
+      return query.andWhere(filterByAction('revoke'));
 
     case 'transfers':
       return query.andWhere(filterByAction('transfer'));
@@ -24,5 +31,8 @@ module.exports = pplType => query => {
 
     case 'ra':
       return query.andWhere(filterByAction('grant-ra'));
+
+    default:
+      throw new Error(`Unrecognised pplType: ${pplType}`);
   }
 };


### PR DESCRIPTION
RA tasks should not display if the user has filtered to "Applications" or "Amendments", so exclude them by requiring a `grant` action (since RA tasks have a `grant-ra` action).

Also add new filter for PPL revocation tasks.