### PR TITLE
Remove PPL amendments from continuations filter

### DIFF
--- a/lib/query-builders/filters/by-ppl-type.js
+++ b/lib/query-builders/filters/by-ppl-type.js
@@ -20,9 +20,11 @@ module.exports = pplType => query => {
       return query.andWhere(filterByAction('transfer'));
 
     case 'continuations':
-      return query.andWhere(builder => {
-        builder.whereRaw("data \\? 'continuation'");
-      });
+      return query
+        .andWhere(filterByIsAmendment(false))
+        .andWhere(builder => {
+          builder.whereRaw("data \\? 'continuation'");
+        });
 
     case 'hasDeadline':
       return query.andWhere(builder => {


### PR DESCRIPTION
Continuation is only relevant for first-time applications and not amendments, so exclude amendments from the list when filtering to continuations.