### PR TITLE
Update PIL endorsed hook to preserve inspector referral

### DIFF
--- a/lib/hooks/endorsed/pil.js
+++ b/lib/hooks/endorsed/pil.js
@@ -1,5 +1,6 @@
 const { get } = require('lodash');
-const { resolved, withLicensing } = require('../../flow/status');
+const { resolved, withLicensing, withInspectorate, referredToInspector } = require('../../flow/status');
+const { withASRU } = require('../../flow');
 
 module.exports = settings => {
   return model => {
@@ -9,6 +10,11 @@ module.exports = settings => {
       return model.setStatus(resolved.id);
     }
 
+    const withASRUStatuses = withASRU();
+    const lastASRUStatus = model.activityLog.map(a => a.event.status).find(status => withASRUStatuses.includes(status));
+    if (lastASRUStatus === referredToInspector.id) {
+      return model.setStatus(withInspectorate.id);
+    }
     return model.setStatus(withLicensing.id);
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3483,9 +3483,9 @@
       }
     },
     "@ukhomeoffice/taskflow": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/taskflow/-/taskflow-2.5.0.tgz",
-      "integrity": "sha512-0DHYp/ToJDA27Zc8CHugQycVpluTlNB41ufZqv4PlrzQhsMweX5qv2CoFgFtXij6SKTtinNPFLmWVIBumqGzHg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/taskflow/-/taskflow-2.5.1.tgz",
+      "integrity": "sha512-zG3iEMFJj962R1/uTCD4hXzzrNJ8Uqd3i3VBuJEIIF2x7uB4EwwFfi6tuJUlJzY4fQlP0RkN4uaGuHjsz5nLqA==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.3",
@@ -3549,44 +3549,6 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "pg": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
-          "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
-          "requires": {
-            "buffer-writer": "2.0.0",
-            "packet-reader": "1.0.0",
-            "pg-connection-string": "^2.5.0",
-            "pg-pool": "^3.3.0",
-            "pg-protocol": "^1.5.0",
-            "pg-types": "^2.1.0",
-            "pgpass": "1.x"
-          },
-          "dependencies": {
-            "pg-connection-string": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-              "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
-            }
-          }
-        },
-        "pg-pool": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
-          "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg=="
-        },
-        "pg-types": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-          "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-          "requires": {
-            "pg-int8": "1.0.1",
-            "postgres-array": "~2.0.0",
-            "postgres-bytea": "~1.0.0",
-            "postgres-date": "~1.0.4",
-            "postgres-interval": "^1.1.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@asl/constants": "^0.8.1",
     "@asl/schema": "^10.5.0",
     "@asl/service": "^8.8.4",
-    "@ukhomeoffice/taskflow": "^2.5.0",
+    "@ukhomeoffice/taskflow": "^2.5.1",
     "aws-sdk": "^2.270.1",
     "deep-diff": "^1.0.2",
     "express": "^4.16.4",

--- a/test/helpers/database-settings.js
+++ b/test/helpers/database-settings.js
@@ -5,12 +5,12 @@ module.exports = {
     host: process.env.ASL_DATABASE_HOST || 'localhost',
     database: process.env.ASL_DATABASE_NAME || 'asl-test',
     user: process.env.ASL_DATABASE_USERNAME || 'postgres',
-    password: process.env.ASL_DATABASE_PASSWORD
+    password: process.env.ASL_DATABASE_PASSWORD || 'test-password'
   },
   taskflowDB: {
     host: process.env.DATABASE_HOST || 'localhost',
     database: process.env.DATABASE_NAME || 'taskflow-test',
     user: process.env.DATABASE_USERNAME || 'postgres',
-    password: process.env.DATABASE_PASSWORD
+    password: process.env.DATABASE_PASSWORD || 'test-password'
   }
 };

--- a/test/helpers/history.js
+++ b/test/helpers/history.js
@@ -1,13 +1,13 @@
 const flow = require('../../lib/flow');
 
-const History = () => {
+const History = (model) => {
 
-  const model = {
+  model = model || {
     status: 'new',
     withASRU: false,
     createdAt: '2019-09-20T10:00:00.000Z',
     activityLog: [
-      { eventName: 'create', createdAt: '2019-09-20T10:00:00.000Z' }
+      { eventName: 'create', event: {}, createdAt: '2019-09-20T10:00:00.000Z' }
     ]
   };
 

--- a/test/unit/hooks/endorsed/pil.js
+++ b/test/unit/hooks/endorsed/pil.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const {
+  awaitingEndorsement,
+  withInspectorate,
+  withLicensing,
+  returnedToApplicant,
+  referredToInspector
+} = require('../../../../lib/flow/status');
+const History = require('../../../helpers/history');
+const hook = require('../../../../lib/hooks/endorsed/pil');
+
+const runHook = hook({});
+
+describe('PIL endorse hook', () => {
+
+  beforeEach(() => {
+    this.model = {
+      data: {
+        model: 'pil',
+        action: 'grant',
+        data: {}
+      },
+      meta: {
+        user: {}
+      },
+      activityLog: [],
+      setStatus: sinon.stub(),
+      patch: sinon.stub()
+    };
+  });
+
+  it('moves task to licensing by default', () => {
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.ok(this.model.setStatus.calledOnce);
+        assert.ok(this.model.setStatus.calledWith(withLicensing.id));
+      });
+  });
+
+  it('moves task to inspectors if it was previously referred', () => {
+    const history = History(this.model);
+    history.status(withLicensing.id);
+    history.status(referredToInspector.id);
+    history.status(returnedToApplicant.id);
+    history.status(awaitingEndorsement.id);
+
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.ok(this.model.setStatus.calledOnce);
+        assert.ok(this.model.setStatus.calledWith(withInspectorate.id));
+      });
+  });
+
+});


### PR DESCRIPTION
If a PIL task has been previously referred to an inspector then when it is resubmitted (endorsed) then it should be directed back to an inspector and not sent to licensing.