### PR TITLE
if returned PIL was with inspectorate return to inspectorate

### DIFF
--- a/lib/hooks/endorsed/pil.js
+++ b/lib/hooks/endorsed/pil.js
@@ -12,7 +12,8 @@ module.exports = settings => {
 
     const withASRUStatuses = withASRU();
     const lastASRUStatus = model.activityLog.map(a => a.event.status).find(status => withASRUStatuses.includes(status));
-    if (lastASRUStatus === referredToInspector.id) {
+
+    if ([withInspectorate.id, referredToInspector.id].includes(lastASRUStatus)) {
       return model.setStatus(withInspectorate.id);
     }
     return model.setStatus(withLicensing.id);

--- a/test/unit/hooks/endorsed/pil.js
+++ b/test/unit/hooks/endorsed/pil.js
@@ -54,4 +54,22 @@ describe('PIL endorse hook', () => {
       });
   });
 
+  it('moves task to inspectors if it was previously with inspectorate', () => {
+    const history = History(this.model);
+    history.status(withLicensing.id);
+    history.status(referredToInspector.id);
+    history.status(returnedToApplicant.id);
+    history.status(awaitingEndorsement.id);
+    history.status(withInspectorate.id);
+    history.status(returnedToApplicant.id);
+    history.status(awaitingEndorsement.id);
+
+    return Promise.resolve()
+      .then(() => runHook(this.model))
+      .then(() => {
+        assert.ok(this.model.setStatus.calledOnce);
+        assert.ok(this.model.setStatus.calledWith(withInspectorate.id));
+      });
+  });
+
 });


### PR DESCRIPTION
If a PIL task is referred to an inspector, and then returned, then when it is endorsed it gets passed directly to the inspectorate by setting the status to `with-inspectorate`.

If this same task is then returned / recalled a second time, the last ASRU status will be `with-inspectorate` so we need to check for this as well.