### PR TITLE
Add helper for generating realistic task data from minimal input

### DIFF
--- a/seeds/helpers/create-task.js
+++ b/seeds/helpers/create-task.js
@@ -1,0 +1,72 @@
+const schema = require('@asl/schema');
+const { v4: uuid } = require('uuid');
+const config = require('../../config');
+module.exports = knex => async (opts = {}) => {
+
+  const { Project, ProjectVersion, Profile } = schema(config.db);
+
+  if (opts.model === 'project') {
+
+    const modelData = await Project.query().findById(opts.id);
+    const version = await ProjectVersion.query()
+      .select('id')
+      .where({ projectId: opts.id, status: 'submitted' })
+      .orderBy('updatedAt', 'desc')
+      .first();
+    const changedBy = opts.changedBy || modelData.licenceHolderId;
+
+    const id = uuid();
+    const status = opts.status || 'with-inspectorate';
+    const profile = await Profile.query().findById(changedBy).withGraphFetched('establishments');
+
+    const task = {
+      id,
+      status,
+      data: {
+        model: 'project',
+        action: opts.action || 'grant',
+        id: opts.id,
+        data: {
+          version: version.id,
+          licenceHolderId: modelData.licenceHolderId,
+          establishmentId: modelData.establishmentId
+        },
+        meta: {
+
+        },
+        subject: modelData.licenceHolderId,
+        establishmentId: modelData.establishmentId,
+        changedBy,
+        modelData
+      }
+    };
+
+    const activity = [
+      {
+        id: uuid(),
+        case_id: id,
+        event_name: `status:new:${status}`,
+        changed_by: profile.id,
+        event: {
+          id: uuid,
+          data: task,
+          event: `status:new:${status}`,
+          status,
+          meta: {
+            user: {
+              profile
+            }
+          }
+        }
+      }
+    ];
+
+    await knex('cases').insert(task);
+    await knex('activity_log').insert(activity);
+    return;
+
+  }
+
+  throw new Error(`Unsupported model: ${opts.model}`);
+
+};

--- a/seeds/tables/cases.js
+++ b/seeds/tables/cases.js
@@ -2,8 +2,19 @@ const uuidv4 = require('uuid/v4');
 const moment = require('moment');
 const cases = require('../data/cases.json');
 
+const createTask = require('../helpers/create-task');
+
 module.exports = {
-  populate: knex => {
+  populate: async knex => {
+
+    const makeTask = createTask(knex);
+
+    await makeTask({
+      id: '782732c5-4457-46d6-9d46-6610a0ecf872',
+      model: 'project',
+      action: 'grant'
+    });
+
     return Promise.all(cases.map(c => {
       if (c.id === '71bd42e1-7cd7-4d51-8d99-694bd4c14810') {
         // keep the dates current so that the deadline is in the future


### PR DESCRIPTION
Only works for project grant at the moment, but it looks up the actual project data and populates a best effort of what a task and activity log would look like for an application submission.

This seems easier than hard-coding everythign manually.

This particular instance won't work until https://github.com/UKHomeOffice/asl-schema/pull/532 is merged.