### PR TITLE
Save applicant's training profile at the point of submission for endorsement

### DIFF
--- a/lib/hooks/create/project.js
+++ b/lib/hooks/create/project.js
@@ -119,6 +119,7 @@ module.exports = settings => {
       case 'transfer':
         return Promise.resolve()
           .then(() => markContinuation(model))
+          .then(() => messager({ ...model.data, action: 'sync-training' }))
           .then(() => {
             if (!requiresEndorsement(model)) {
               return messager({ ...model.data, action: 'submit-draft' });


### PR DESCRIPTION
Previously the training profile was only saved to the version at the point of submission to ASRU, so when an admin user was reviewing an application for endorsement it would always show as having no training record.