### PR TITLE
Add internal deadline hook and integration test

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -31,6 +31,7 @@ const hooks = {
   unique: require('./hooks/create/unique'),
   updateData: require('./hooks/update-data'),
   setDeadline: require('./hooks/set-deadline'),
+  setInternalDeadline: require('./hooks/set-internal-deadline'),
   clearDeadline: require('./hooks/clear-deadline'),
   meta: require('./hooks/meta'),
   modelData: require('./hooks/model-data'),
@@ -93,6 +94,7 @@ module.exports = settings => {
   flow.hook(`status:*:${resubmitted.id}`, hooks.submissionMeta(settings));
   flow.hook(`status:*:${resubmitted.id}`, hooks.create(settings));
   flow.hook(`status:*:${withInspectorate.id}`, hooks.setDeadline(settings));
+  flow.hook(`status:*:${withInspectorate.id}`, hooks.setInternalDeadline(settings));
 
   flow.hook(`status:*:${recalledByApplicant.id}`, hooks.clearDeadline(settings));
   flow.hook(`status:*:${returnedToApplicant.id}`, hooks.clearDeadline(settings));

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "moment": "^2.24.0",
-        "moment-business-time": "^0.7.1",
+        "moment-business-time": "^2.0.0",
         "node-fetch": "^2.6.7",
         "objection": "^2.2.17",
         "uuid": "^3.3.2"
@@ -10591,12 +10591,12 @@
       }
     },
     "node_modules/moment-business-time": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/moment-business-time/-/moment-business-time-0.7.1.tgz",
-      "integrity": "sha512-b36rt0KFOyiXLaaUQlgjIXGicaa4vCja3AF84bRSY+3sHPDIkLflUKVMgqNFpZ1kzkKox+617pEDqx5YFZRVHA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/moment-business-time/-/moment-business-time-2.0.0.tgz",
+      "integrity": "sha512-1eB16mrhj/OIQN/sm1YW1tO4nt1Kajd0kZvlRiAuXCXTXCjHqDFZTjUu5h/uJXQpL7jzhh8JiXhf40btleqI2w==",
       "dependencies": {
         "minimatch": "^3.0.3",
-        "moment": "^2.14.1"
+        "moment": "^2.24.0"
       }
     },
     "node_modules/morgan": {
@@ -19242,6 +19242,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -22958,12 +22959,12 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-business-time": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/moment-business-time/-/moment-business-time-0.7.1.tgz",
-      "integrity": "sha512-b36rt0KFOyiXLaaUQlgjIXGicaa4vCja3AF84bRSY+3sHPDIkLflUKVMgqNFpZ1kzkKox+617pEDqx5YFZRVHA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/moment-business-time/-/moment-business-time-2.0.0.tgz",
+      "integrity": "sha512-1eB16mrhj/OIQN/sm1YW1tO4nt1Kajd0kZvlRiAuXCXTXCjHqDFZTjUu5h/uJXQpL7jzhh8JiXhf40btleqI2w==",
       "requires": {
         "minimatch": "^3.0.3",
-        "moment": "^2.14.1"
+        "moment": "^2.24.0"
       }
     },
     "morgan": {
@@ -23218,6 +23219,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -26038,6 +26040,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.17.21",
     "minimatch": "^3.0.4",
     "moment": "^2.24.0",
-    "moment-business-time": "^0.7.1",
+    "moment-business-time": "^2.0.0",
     "node-fetch": "^2.6.7",
     "objection": "^2.2.17",
     "uuid": "^3.3.2"

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -211,24 +211,27 @@ module.exports = models => {
               {
                 id: uuid(),
                 title: 'Test project 1',
-                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                licenceHolderId: holc.id,
                 expiryDate: '2040-01-01T12:00:00Z',
+                status: 'active',
                 licenceNumber: 'abc123'
               },
               {
                 id: uuid(),
                 title: 'Test project 3',
-                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                licenceHolderId: holc.id,
                 expiryDate: '2010-01-01T12:00:00Z',
+                status: 'active',
                 licenceNumber: 'abc456'
               },
               {
                 id: ids.model.project.updateIssueDate,
                 title: 'Test project 4',
-                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                licenceHolderId: holc.id,
                 issueDate: '2020-01-01T12:00:00Z',
                 expiryDate: '2025-01-01T12:00:00Z',
                 licenceNumber: 'xyz123',
+                status: 'active',
                 version: [
                   {
                     id: '6cd77ff4-8de7-4b10-8d5c-e9bdbf65ccfb',
@@ -246,6 +249,7 @@ module.exports = models => {
                 issueDate: '2020-01-01T12:00:00Z',
                 expiryDate: '2025-01-01T12:00:00Z',
                 licenceNumber: 'xyz123',
+                status: 'active',
                 version: [
                   {
                     id: ids.model.projectVersion.transfer,
@@ -263,6 +267,7 @@ module.exports = models => {
                 issueDate: '2020-01-01T12:00:00Z',
                 expiryDate: '2025-01-01T12:00:00Z',
                 licenceNumber: 'xyz123',
+                status: 'active',
                 version: [
                   {
                     id: uuid(),
@@ -281,6 +286,7 @@ module.exports = models => {
                 expiryDate: '2025-01-01T12:00:00Z',
                 licenceNumber: 'xyz123',
                 isLegacyStub: true,
+                status: 'active',
                 version: [
                   {
                     id: uuid(),
@@ -298,6 +304,7 @@ module.exports = models => {
                 issueDate: '2020-01-01T12:00:00Z',
                 expiryDate: '2025-01-01T12:00:00Z',
                 licenceNumber: '70/1234',
+                status: 'active',
                 version: [
                   {
                     id: ids.model.projectVersion.recalledTransfer,
@@ -308,10 +315,8 @@ module.exports = models => {
               {
                 id: ids.model.project.grant,
                 title: 'Test project 9',
-                licenceHolderId: userAtMultipleEstablishments.id,
-                issueDate: '2020-01-01T12:00:00Z',
-                expiryDate: '2025-01-01T12:00:00Z',
-                licenceNumber: '70/1235',
+                licenceHolderId: holc.id,
+                status: 'inactive',
                 version: [
                   {
                     id: ids.model.projectVersion.grant,
@@ -324,12 +329,32 @@ module.exports = models => {
                 ]
               },
               {
+                id: ids.model.project.amend,
+                title: 'Test project 9',
+                licenceHolderId: holc.id,
+                issueDate: '2020-01-01T12:00:00Z',
+                expiryDate: '2025-01-01T12:00:00Z',
+                licenceNumber: '70/1235',
+                status: 'active',
+                version: [
+                  {
+                    id: ids.model.projectVersion.amend,
+                    status: 'draft'
+                  },
+                  {
+                    id: ids.model.projectVersion.amend2,
+                    status: 'granted'
+                  }
+                ]
+              },
+              {
                 id: ids.model.project.rejection,
                 title: 'Test project for rejection',
                 licenceHolderId: holc.id,
                 issueDate: '2020-01-01T12:00:00Z',
                 expiryDate: '2025-01-01T12:00:00Z',
                 licenceNumber: '70/1235',
+                status: 'active',
                 version: [
                   {
                     id: ids.model.projectVersion.rejection,
@@ -344,10 +369,11 @@ module.exports = models => {
               {
                 id: ids.model.project.revoke,
                 title: 'Test revocation project',
-                licenceHolderId: 'f0835b01-00a0-4c7f-954c-13ed2ef7efd9',
+                licenceHolderId: holc.id,
                 issueDate: '2020-01-01T12:00:00Z',
                 expiryDate: '2025-01-01T12:00:00Z',
                 licenceNumber: '70/1235',
+                status: 'active',
                 version: [
                   {
                     id: uuid(),
@@ -372,9 +398,7 @@ module.exports = models => {
                 id: ids.model.project.continuation,
                 title: 'Test project 9',
                 licenceHolderId: user.id,
-                issueDate: '2020-01-01T12:00:00Z',
-                expiryDate: '2025-01-01T12:00:00Z',
-                licenceNumber: '70/1235',
+                status: 'inactive',
                 version: [
                   {
                     id: ids.model.projectVersion.continuation,
@@ -395,9 +419,7 @@ module.exports = models => {
                 id: ids.model.project.continuation2,
                 title: 'Test project 10',
                 licenceHolderId: userWithActivePil.id,
-                issueDate: '2020-01-01T12:00:00Z',
-                expiryDate: '2025-01-01T12:00:00Z',
-                licenceNumber: '70/1235',
+                status: 'inactive',
                 version: [
                   {
                     id: ids.model.projectVersion.continuation2,
@@ -418,9 +440,7 @@ module.exports = models => {
                 id: ids.model.project.notAContinuation,
                 title: 'Test project 11',
                 licenceHolderId: user.id,
-                issueDate: '2020-01-01T12:00:00Z',
-                expiryDate: '2025-01-01T12:00:00Z',
-                licenceNumber: '70/1236',
+                status: 'inactive',
                 version: [
                   {
                     id: ids.model.projectVersion.notAContinuation,
@@ -473,6 +493,7 @@ module.exports = models => {
                 title: 'Test project 2',
                 licenceHolderId: 'ae28fb31-d867-4371-9b4f-79019e71232e',
                 expiryDate: '2040-01-01T12:00:00Z',
+                status: 'active',
                 licenceNumber: 'abc789'
               }
             ]

--- a/test/data/ids.js
+++ b/test/data/ids.js
@@ -66,6 +66,7 @@ module.exports = {
     },
     project: {
       grant: uuid(),
+      amend: uuid(),
       rejection: uuid(),
       transfer: uuid(),
       transfer2: uuid(),
@@ -93,7 +94,9 @@ module.exports = {
       transfer: uuid(),
       transfer2: uuid(),
       grant: uuid(),
-      grant2: uuid()
+      grant2: uuid(),
+      amend: uuid(),
+      amend2: uuid()
     },
     rop: {
       draft: uuid(),

--- a/test/integration/hooks/deadlines.js
+++ b/test/integration/hooks/deadlines.js
@@ -1,0 +1,124 @@
+const request = require('supertest');
+const assert = require('assert');
+const moment = require('moment-business-time');
+const workflowHelper = require('../../helpers/workflow');
+const { holc } = require('../../data/profiles');
+const ids = require('../../data/ids');
+
+describe('Project deadlines', () => {
+  before(() => {
+    return workflowHelper.create()
+      .then(workflow => {
+        this.workflow = workflow;
+      });
+  });
+
+  beforeEach(() => {
+    return this.workflow.resetDBs();
+  });
+
+  after(() => {
+    return this.workflow.destroy();
+  });
+
+  it('sets internal deadline for a first time submission', () => {
+    this.workflow.setUser({ profile: holc });
+    return request(this.workflow)
+      .post('/')
+      .send({
+        model: 'project',
+        action: 'grant',
+        id: ids.model.project.grant,
+        changedBy: holc.id,
+        data: {
+          version: ids.model.projectVersion.grant,
+          establishmentId: 100
+        }
+      })
+      .expect(200)
+      .then(response => response.body)
+      .then(body => {
+        assert.ok(body.data.data.internalDeadline.standard);
+        assert.equal(moment(body.data.data.internalDeadline.standard).workingDiff(moment(), 'calendarDays'), 40);
+      });
+  });
+
+  it('sets internal deadline for an amendment', () => {
+    this.workflow.setUser({ profile: holc });
+
+    return request(this.workflow)
+      .post('/')
+      .send({
+        model: 'project',
+        action: 'grant',
+        id: ids.model.project.amend,
+        changedBy: holc.id,
+        data: {
+          version: ids.model.projectVersion.amend,
+          establishmentId: 100
+        }
+      })
+      .expect(200)
+      .then(response => response.body)
+      .then(body => {
+        assert.ok(body.data.data.internalDeadline.standard);
+        assert.equal(moment(body.data.data.internalDeadline.standard).workingDiff(moment(), 'calendarDays'), 20);
+      });
+  });
+
+  it('sets statutory deadline for first time application if complete and correct', () => {
+    this.workflow.setUser({ profile: holc });
+    return request(this.workflow)
+      .post('/')
+      .send({
+        model: 'project',
+        action: 'grant',
+        id: ids.model.project.grant,
+        changedBy: holc.id,
+        data: {
+          version: ids.model.projectVersion.grant,
+          establishmentId: 100
+        },
+        meta: {
+          ready: 'yes',
+          awerb: 'yes',
+          authority: 'yes'
+        }
+      })
+      .expect(200)
+      .then(response => response.body)
+      .then(body => {
+        assert.ok(body.data.data.deadline);
+        assert.equal(moment(body.data.data.deadline.standard).workingDiff(moment(), 'calendarDays'), 40);
+        assert.equal(moment(body.data.data.deadline.extended).workingDiff(moment(), 'calendarDays'), 55);
+      });
+  });
+
+  it('does not set sets statutory deadline for amendment', () => {
+    this.workflow.setUser({ profile: holc });
+
+    return request(this.workflow)
+      .post('/')
+      .send({
+        model: 'project',
+        action: 'grant',
+        id: ids.model.project.amend,
+        changedBy: holc.id,
+        data: {
+          version: ids.model.projectVersion.amend,
+          establishmentId: 100
+        },
+        meta: {
+          ready: 'yes',
+          awerb: 'yes',
+          authority: 'yes'
+        }
+      })
+      .expect(200)
+      .then(response => response.body)
+      .then(body => {
+        assert.ok(!body.data.data.deadline);
+      });
+  });
+
+});

--- a/test/integration/hooks/model-data.js
+++ b/test/integration/hooks/model-data.js
@@ -89,7 +89,7 @@ describe('Model data hook', () => {
         .expect(200)
         .then(response => response.body.data)
         .then(task => {
-          assert.equal(task.data.modelData.status, 'inactive');
+          assert.equal(task.data.modelData.status, 'active');
           assert.equal(task.data.modelData.licenceHolder.firstName, 'Colin');
         });
     });


### PR DESCRIPTION
Adding the integration tests for deadlines meant setting the project statuses in the seeds to appropriate values, which had some interesting side-effects - in particular a test that was effectively noop-ing for changing licence holders on stub licences because all the projects were `inactive`.