### PR TITLE
decorate task with active deadline

### DIFF
--- a/lib/decorators/deadline/index.js
+++ b/lib/decorators/deadline/index.js
@@ -1,28 +1,39 @@
 const { get } = require('lodash');
+const moment = require('moment');
 const { Task } = require('@ukhomeoffice/taskflow');
 const { withASRU } = require('../../flow');
 
 const completeAndCorrect = require('./complete-and-correct');
 const getDeadline = require('./get-deadline');
 
-const hasActiveDeadline = task => {
-  const model = get(task, 'data.model');
-  const action = get(task, 'data.action');
-  const status = get(task, 'status');
+const statutoryDeadlineActivated = task => {
   const isAmendment = get(task, 'data.modelData.status') !== 'inactive';
   const meta = get(task, 'data.meta');
-
-  if (model !== 'project' || action !== 'grant' || !withASRU().includes(status) || isAmendment) {
-    return false;
-  }
-
-  return completeAndCorrect(meta);
+  return !isAmendment && completeAndCorrect(meta);
 };
 
-module.exports = settings => {
+const getActiveDeadline = task => {
+  const now = new Date();
+  const statutoryDeadline = get(task, 'data.deadline');
+  const isExtended = get(statutoryDeadline, 'isExtended', false);
+  const statutoryDate = get(statutoryDeadline, isExtended ? 'extended' : 'standard');
+  const internalDeadline = get(task, 'data.internalDeadline');
+  const internalDate = get(internalDeadline, isExtended ? 'extended' : 'standard');
+  const internalPassed = internalDate && moment(internalDate).isBefore(now);
+  const earliestDate = [internalDate, statutoryDate].filter(Boolean).sort().shift();
+
+  return (!internalPassed || !statutoryDate) && earliestDate
+    ? earliestDate
+    : statutoryDate;
+};
+
+module.exports = () => {
   return task => {
-    if (!hasActiveDeadline(task)) {
-      delete task.data.deadline;
+    const model = get(task, 'data.model');
+    const action = get(task, 'data.action');
+    const status = get(task, 'status');
+
+    if (model !== 'project' || action !== 'grant' || !withASRU().includes(status)) {
       return Promise.resolve(task);
     }
 
@@ -34,15 +45,17 @@ module.exports = settings => {
         return task;
       })
       .then(model => {
-        const deadline = getDeadline(model);
+        if (statutoryDeadlineActivated(task)) {
+          task.data.deadline = getDeadline(model);
+        } else {
+          delete task.data.deadline;
+        }
 
-        return {
-          ...task,
-          data: {
-            ...task.data,
-            deadline
-          }
-        };
+        if (!task.activeDeadline) {
+          task.activeDeadline = getActiveDeadline(task);
+        }
+
+        return task;
       });
   };
 };

--- a/lib/decorators/deadline/index.js
+++ b/lib/decorators/deadline/index.js
@@ -34,6 +34,7 @@ module.exports = () => {
     const status = get(task, 'status');
 
     if (model !== 'project' || action !== 'grant' || !withASRU().includes(status)) {
+      delete task.data.deadline;
       return Promise.resolve(task);
     }
 

--- a/lib/hooks/set-internal-deadline/index.js
+++ b/lib/hooks/set-internal-deadline/index.js
@@ -28,20 +28,25 @@ module.exports = () => {
 
     if (isAmendment) {
       const interval = resubmitted ? AMENDMENT_RESUBMISSION_DEADLINE : AMENDMENT_DEADLINE;
+      const amendmentDeadline = moment(task.updatedAt).addWorkingTime(interval, 'days').format('YYYY-MM-DD');
       internalDeadline = {
-        standard: moment(task.updatedAt).addWorkingTime(interval, 'days').format('YYYY-MM-DD'),
+        standard: amendmentDeadline,
+        extended: amendmentDeadline, // amendment deadline can't be extended
         resubmitted
       };
     } else {
       if (resubmitted) {
+        const resubmissionDeadline = moment(task.updatedAt).addWorkingTime(RESUBMISSION_DEADLINE, 'days').format('YYYY-MM-DD');
         internalDeadline = {
-          standard: moment(task.updatedAt).addWorkingTime(RESUBMISSION_DEADLINE, 'days').format('YYYY-MM-DD'),
-          resubmitted: true
+          standard: resubmissionDeadline,
+          extended: resubmissionDeadline, // resubmission deadline can't be extended
+          resubmitted
         };
       } else {
         internalDeadline = {
           standard: moment(task.updatedAt).addWorkingTime(STANDARD_DEADLINE, 'days').format('YYYY-MM-DD'),
-          extended: moment(task.updatedAt).addWorkingTime(EXTENDED_DEADLINE, 'days').format('YYYY-MM-DD')
+          extended: moment(task.updatedAt).addWorkingTime(EXTENDED_DEADLINE, 'days').format('YYYY-MM-DD'),
+          resubmitted
         };
       }
     }

--- a/seeds/data/internal-deadline-cases.js
+++ b/seeds/data/internal-deadline-cases.js
@@ -12,7 +12,8 @@ const projects = [
     licenceNumber: 'INTDL-FUT',
     data: {
       internalDeadline: {
-        standard: moment().addWorkingTime(STANDARD_DEADLINE, 'days').format('YYYY-MM-DD')
+        standard: moment().addWorkingTime(STANDARD_DEADLINE, 'days').format('YYYY-MM-DD'),
+        extended: moment().addWorkingTime(EXTENDED_DEADLINE, 'days').format('YYYY-MM-DD')
       }
     }
   },
@@ -21,7 +22,8 @@ const projects = [
     licenceNumber: 'INTDL-URG',
     data: {
       internalDeadline: {
-        standard: moment().addWorkingTime(5, 'days').format('YYYY-MM-DD')
+        standard: moment().addWorkingTime(5, 'days').format('YYYY-MM-DD'),
+        extended: moment().addWorkingTime(20, 'days').format('YYYY-MM-DD')
       }
     }
   },
@@ -30,7 +32,8 @@ const projects = [
     licenceNumber: 'INTDL-PAST',
     data: {
       internalDeadline: {
-        standard: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD')
+        standard: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD'),
+        extended: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD')
       }
     }
   },
@@ -39,7 +42,8 @@ const projects = [
     licenceNumber: 'INTDL-STAT-FUT',
     data: {
       internalDeadline: {
-        standard: moment().addWorkingTime(STANDARD_DEADLINE, 'days').format('YYYY-MM-DD')
+        standard: moment().addWorkingTime(STANDARD_DEADLINE, 'days').format('YYYY-MM-DD'),
+        extended: moment().addWorkingTime(EXTENDED_DEADLINE, 'days').format('YYYY-MM-DD')
       },
       deadline: {
         standard: moment().addWorkingTime(STANDARD_DEADLINE, 'days').format('YYYY-MM-DD'),
@@ -53,7 +57,8 @@ const projects = [
     licenceNumber: 'INTDL-EARLY-STAT',
     data: {
       internalDeadline: {
-        standard: moment().addWorkingTime(RESUBMISSION_DEADLINE, 'days').format('YYYY-MM-DD')
+        standard: moment().addWorkingTime(RESUBMISSION_DEADLINE, 'days').format('YYYY-MM-DD'),
+        extended: moment().addWorkingTime(RESUBMISSION_DEADLINE, 'days').format('YYYY-MM-DD')
       },
       deadline: {
         standard: moment().addWorkingTime(STANDARD_DEADLINE, 'days').format('YYYY-MM-DD'),
@@ -67,7 +72,8 @@ const projects = [
     licenceNumber: 'INTDL-PAST-STAT-FUT',
     data: {
       internalDeadline: {
-        standard: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD')
+        standard: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD'),
+        extended: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD')
       },
       deadline: {
         standard: moment().addWorkingTime(STANDARD_DEADLINE, 'days').format('YYYY-MM-DD'),
@@ -81,7 +87,8 @@ const projects = [
     licenceNumber: 'INTDL-PAST-STAT-PAST',
     data: {
       internalDeadline: {
-        standard: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD')
+        standard: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD'),
+        extended: moment().subtractWorkingTime(13, 'days').format('YYYY-MM-DD')
       },
       deadline: {
         standard: moment().subtractWorkingTime(2, 'days').format('YYYY-MM-DD'),

--- a/test/unit/hooks/set-internal-deadline/index.js
+++ b/test/unit/hooks/set-internal-deadline/index.js
@@ -90,6 +90,7 @@ describe('Set internal deadline hook', () => {
       const expected = {
         internalDeadline: {
           standard: moment().addWorkingTime(20, 'days').format('YYYY-MM-DD'),
+          extended: moment().addWorkingTime(20, 'days').format('YYYY-MM-DD'),
           resubmitted: false
         }
       };
@@ -129,6 +130,7 @@ describe('Set internal deadline hook', () => {
       const expected = {
         internalDeadline: {
           standard: moment().addWorkingTime(15, 'days').format('YYYY-MM-DD'),
+          extended: moment().addWorkingTime(15, 'days').format('YYYY-MM-DD'),
           resubmitted: true
         }
       };
@@ -166,7 +168,8 @@ describe('Set internal deadline hook', () => {
       const expected = {
         internalDeadline: {
           standard: moment().addWorkingTime(40, 'days').format('YYYY-MM-DD'),
-          extended: moment().addWorkingTime(55, 'days').format('YYYY-MM-DD')
+          extended: moment().addWorkingTime(55, 'days').format('YYYY-MM-DD'),
+          resubmitted: false
         }
       };
 
@@ -205,6 +208,7 @@ describe('Set internal deadline hook', () => {
       const expected = {
         internalDeadline: {
           standard: moment().addWorkingTime(20, 'days').format('YYYY-MM-DD'),
+          extended: moment().addWorkingTime(20, 'days').format('YYYY-MM-DD'),
           resubmitted: true
         }
       };


### PR DESCRIPTION
The task list endpoint now has the active deadline populated by the query itself, but the route to fetch an individual task is in `taskflow` not `asl-workflow` hence the decorator rather than modifying the query.