### PR TITLE
Mark deadlines as passed after seeding

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:unit": "mocha ./test",
     "dev": "nodemon -r dotenv/config index.js",
     "seed": "SNAKE_MAPPER=true knex seed:run",
+    "postseed": "bin/deadline-has-passed",
     "migrate": "node ./scripts/migrate.js",
     "migrate:test": "node ./scripts/migrate-test.js"
   },


### PR DESCRIPTION
There are some tasks wih expired deadlines that are not seeded as expired, but are ignored by the reports because the flags are added as a nightly cron.

When seeding data run the script immediately so all tasks are flagged.