### PR TITLE
Add redundant secondary sort order to query builder

### DIFF
--- a/lib/query-builders/index.js
+++ b/lib/query-builders/index.js
@@ -136,6 +136,7 @@ module.exports = ({ profile, sort = { column: 'updatedAt' }, limit, offset, filt
   let query = buildQuery(progress, profile, filters);
   query = selectActiveDeadline(query);
   query = Task.orderBy({ query, sort });
+  query = Task.orderBy({ query, sort: { column: 'id' } });
   query = Task.paginate({ query, limit, offset });
 
   query.total = () => {


### PR DESCRIPTION
There is an issue in postgres where queries with `limit` defined can run very slowly when sorted by an indexed column because they do a full scan rather than optimising the query.

Adding an arbitrary second sort parameter will resolve the issue.

Details: https://stackoverflow.com/questions/21385555/postgresql-query-very-slow-with-limit-1