### PR TITLE
Remove lookup of associated establishments

### DIFF
--- a/lib/router/tasks.js
+++ b/lib/router/tasks.js
@@ -6,22 +6,8 @@ module.exports = (taskflow, settings) => {
 
   router.get('/', (req, res, next) => {
     const start = process.hrtime();
-    const { Profile } = settings.models;
 
     Promise.resolve()
-      .then(() => {
-        if (req.user.profile && req.user.profile.asruUser) {
-          return Profile.query()
-            .withGraphFetched('asru')
-            .modifyGraph('children', builder => {
-              builder.select('id');
-            })
-            .findOne({ id: req.user.profile.id })
-            .then(({ asru }) => {
-              req.user.profile.asru = asru;
-            });
-        }
-      })
       .then(() => {
         const profile = req.user.profile;
         const query = queryBuilder({ profile, ...req.query });


### PR DESCRIPTION
The concept of ASRU staff having associated establishments is no longer used, and the associations are no longer used downstream in the query builder, so there is no need to load them here.