### PR TITLE
ASL-4082 - task seed for licence with no licenceHolder in DB

### DIFF
--- a/seeds/data/refuse-ppl.js
+++ b/seeds/data/refuse-ppl.js
@@ -22,6 +22,18 @@ module.exports = async makeTask => {
     });
   };
 
+  const applicationSubmittedWithNoLicenceHolderTask = async () => {
+    const eventTime = moment().subtract(1, 'day');
+
+    await makeTask({
+      ...defaultOpts,
+      excludeLicenceHolder: true,
+      id: '482fa74c-56b2-40ca-9dca-6b00d174b5e4',
+      title: 'Refuse PPL: submitted - No licenceHolder on task',
+      date: eventTime.toISOString()
+    });
+  };
+
   const canResubmitTask = async () => {
     const eventTime = moment().subtract(1, 'day');
 
@@ -152,6 +164,7 @@ module.exports = async makeTask => {
   };
 
   await applicationSubmittedTask();
+  await applicationSubmittedWithNoLicenceHolderTask();
   await canResubmitTask();
   await deadlineFutureWithApplicantTask();
   await deadlineFutureWithAsruTask();

--- a/seeds/helpers/create-task.js
+++ b/seeds/helpers/create-task.js
@@ -7,9 +7,18 @@ module.exports = knex => async (opts = {}) => {
 
   if (opts.model === 'project') {
 
-    const modelData = opts.licenceNumber
-      ? await Project.query().findOne({ licenceNumber: opts.licenceNumber }).withGraphFetched('licenceHolder')
-      : await Project.query().findById(opts.id).withGraphFetched('licenceHolder');
+    let query = Project.query();
+    if (opts.licenceNumber) {
+      query = query.findOne({ licenceNumber: opts.licenceNumber });
+    } else {
+      query = query.findById(opts.id);
+    }
+
+    if (!opts.excludeLicenceHolder) {
+      query = query.withGraphFetched('licenceHolder');
+    }
+
+    const modelData = await query;
 
     const version = await ProjectVersion.query()
       .select('id')


### PR DESCRIPTION
Couldn't see an easy way to leave the licenceHolder property in the task data blank so passing through a flag in the opts to not include it.