### PR TITLE
Clear removed deadline from tasks when returning

### DIFF
--- a/lib/hooks/clear-deadline/index.js
+++ b/lib/hooks/clear-deadline/index.js
@@ -5,7 +5,7 @@ module.exports = () => {
     const type = get(model, 'data.model');
 
     if (type === 'project') {
-      return model.patch({ extended: null, deadline: null, internalDeadline: null });
+      return model.patch({ extended: null, deadline: null, internalDeadline: null, removedDeadline: null });
     }
 
     return Promise.resolve();


### PR DESCRIPTION
The presence of the `removedDeadline` property prevents returned and resubmitted PPL tasks from correctly displaying their statutory deadlines when resubmitted.

Clear the `removedDeadline` property as well when returning a PPL to the applicant.