### PR TITLE
Allow inspectors to edit PILs directly

### DIFF
--- a/lib/hooks/create/pil.js
+++ b/lib/hooks/create/pil.js
@@ -15,7 +15,7 @@ module.exports = settings => {
         if (!profile.asruUser) {
           throw new BadRequestError('Only ASRU users can update licence conditions');
         }
-        if (profile.asruUser && profile.asruLicensing) {
+        if (profile.asruUser && (profile.asruLicensing || profile.asruInspector)) {
           return model.setStatus(resolved.id);
         }
         return model.setStatus(withLicensing.id);
@@ -51,7 +51,7 @@ module.exports = settings => {
         return model.setStatus(withLicensing.id);
 
       case 'grant':
-        if (profile.asruUser && profile.asruLicensing) {
+        if (profile.asruUser && (profile.asruLicensing || profile.asruInspector)) {
           return model.setStatus(resolved.id);
         }
         if (profile.asruUser) {


### PR DESCRIPTION
Since inspectors can now grant PIL applications, it doesn't make any sense that if they make an amendment directly that it has to go to a licensing officer for approval.

Allow inspector initiated PIL amendments to be granted directly.