### PR TITLE
Allow inspectors to revoke PILs directly

### DIFF
--- a/lib/hooks/create/pil.js
+++ b/lib/hooks/create/pil.js
@@ -43,8 +43,8 @@ module.exports = settings => {
         return model.setStatus(resolved.id);
 
       case 'revoke':
-        if (profile.asruUser && profile.asruLicensing) {
-          // PIL revoked by licensing, does not need review
+        if (profile.asruUser && (profile.asruLicensing || profile.asruInspector)) {
+          // PIL revoked by licensing or inspector, does not need review
           return model.setStatus(resolved.id);
         }
         // PIL revoked by establishment user - needs licensing review.


### PR DESCRIPTION
The process to amend PILs was changed last week to allow inspectors to not need to go via licensing, but revocations were missed.

Also allow inspectors to revoke PILs directly.