### PR TITLE
knex and objection upgraded - test passing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asl-workflow",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "Workflow API for processing change requests",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "moment": "^2.29.3",
     "moment-business-time": "^2.0.0",
     "node-fetch": "^2.6.7",
-    "objection": "^2.2.17",
+    "objection": "^3.1.5",
     "uuid": "^3.3.2",
     "uuid-validate": "0.0.3"
   },
@@ -50,7 +50,7 @@
     "dotenv": "^6.0.0",
     "eslint": "^5.0.1",
     "@ukhomeoffice/eslint-config-asl": "^3.0.0",
-    "knex": "^0.21.21",
+    "knex": "^3.1.0",
     "mocha": "^10.2.0",
     "nodemon": "^2.0.4",
     "nyc": "^15.1.0",


### PR DESCRIPTION
knex and objection upgrade.
migrate-test -  process.chdir('./node_modules/@asl/schema'); 
When we merge the asl-schema to 11.0.0 will retest.